### PR TITLE
Widgets were parsed wrongly

### DIFF
--- a/HasteForm.php
+++ b/HasteForm.php
@@ -506,10 +506,7 @@ class HasteForm extends Frontend
 				$strBuffer .= '<fieldset>';
 			}
 
-			$strBuffer .= '
-<div class="widget">' .
- $objWidget->generateWithError() . ' ' . (($objWidget instanceof FormCaptcha) ? $objWidget->generateQuestion() : $objWidget->generateLabel()) . 
-'</div>';
+			$strBuffer .= '<div class="widget">' . $objWidget->parse() . '</div>';
 		
 			// end fieldset if we should do that for this widget
 			if ($objWidget->hasteFormFieldSetEnd)


### PR DESCRIPTION
We simply need to call parse() as this method will parse the specific templates that call the needed methods (generateLabel() etc.) themselves.

Otherwise I get the questions twice for a radio field type for instance :)
