### PR TITLE
Allow custom configuration of captcha field

### DIFF
--- a/HasteForm.php
+++ b/HasteForm.php
@@ -517,18 +517,19 @@ class HasteForm extends Frontend
 
 	/**
 	 * Add a captcha field
+	 * @param array
 	 */
-	public function addCaptcha()
+	public function addCaptcha($arrData=array())
 	{
 		if (!isset($this->arrFields['captcha']))
 		{
-			$this->arrFields['captcha'] = array
+			$this->arrFields['captcha'] = array_merge_recursive(array
 			(
 				'name'      => 'captcha',
 				'label'     => $GLOBALS['TL_LANG']['MSC']['securityQuestion'],
 				'inputType' => 'captcha',
 				'eval'      => array('mandatory'=>true)
-			);
+			), $arrData);
 		}
 	}
 


### PR DESCRIPTION
I use this to pass eval=>tableless = true, but any configuration can be passed now.
