### PR TITLE
Problem with generateHiddenFields()

### DIFF
--- a/HasteForm.php
+++ b/HasteForm.php
@@ -734,7 +734,7 @@ window.scrollTo(null, ($(\''. $this->strFormId . '\').getElement(\'p.error\').ge
 
 		foreach ($this->arrHiddenFields as $k=>$v)
 		{
-			$strBuffer .= sprintf('<input type="hidden" name="%s" value="%s"%s', $k, $v, $strTagEnding) . "\n";
+			$strBuffer .= sprintf('<input type="hidden" name="%s" value="%s"%s', $k, $v['value'], $strTagEnding) . "\n";
 		}
 
 		return $strBuffer;


### PR DESCRIPTION
$v = array()

```
<input type="hidden" value="Array" name="published"> 
```

Modified with `$v['value']`

```
<input type="hidden" value="1" name="published">
```
