### PR TITLE
added optional options on json response

### DIFF
--- a/library/Haste/Http/Response/JsonResponse.php
+++ b/library/Haste/Http/Response/JsonResponse.php
@@ -33,10 +33,15 @@ class JsonResponse extends Response
     /**
      * Prepares the content
      * @param   array
+     * @param   integer
      */
-    public function setContent($arrContent)
+    public function setContent($arrContent, $intOptions = null)
     {
-        $strContent = json_encode($arrContent);
+        if ($intOptions !== null) {
+            $strContent = json_encode($arrContent, $intOptions);
+        } else {
+            $strContent = json_encode($arrContent);
+        }
 
         parent::setContent($strContent);
     }


### PR DESCRIPTION
I have been added optional options to the `setContent` method at the `JsonResponse` class.

See more at:
http://de2.php.net/json_encode
