### PR TITLE
added optional options on json response

### DIFF
--- a/library/Haste/Http/Response/JsonResponse.php
+++ b/library/Haste/Http/Response/JsonResponse.php
@@ -34,14 +34,11 @@ class JsonResponse extends Response
      * Prepares the content
      * @param   array
      * @param   integer
+     * @param   integer
      */
-    public function setContent($arrContent, $intOptions = null)
+    public function setContent($arrContent, $intOptions = 0, $intDepth = 512)
     {
-        if ($intOptions !== null) {
-            $strContent = json_encode($arrContent, $intOptions);
-        } else {
-            $strContent = json_encode($arrContent);
-        }
+        $strContent = json_encode($arrContent, $intOptions, $intDepth);
 
         parent::setContent($strContent);
     }


### PR DESCRIPTION
I have been added optional options to the `setContent` method at the `JsonResponse` class.

See more at:
http://de2.php.net/json_encode
