### PR TITLE
Add public constructor.

### DIFF
--- a/library/Haste/Model/Relations.php
+++ b/library/Haste/Model/Relations.php
@@ -27,6 +27,11 @@ class Relations extends \Backend
      */
     private static $arrFilterableFields = array();
 
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
     /**
      * Add the relation callbacks to DCA
      * @param string


### PR DESCRIPTION
When using the `Relations` class outside of a `Backend` compatible class, it is impossible to instanciate the class due too access violation of the protected `Backend` constructor.
