### PR TITLE
Added a function to get the jumpto from the form generator

### DIFF
--- a/library/Haste/Form/Form.php
+++ b/library/Haste/Form/Form.php
@@ -661,6 +661,23 @@ class Form extends \Controller
     }
 
     /**
+     * Add form jumpTo from a back end form generator form ID
+     *
+     * @param int      $intId       The form generator form ID
+     *
+     * @return $this
+     * @throws \InvalidArgumentException
+     */
+    public function addJumpToFromFormGenerator($intId)
+    {
+        if (($objForm = \FormModel::findById($intId)) === null) {
+            throw new \InvalidArgumentException('Form ID "' . $intId . '" does not exist.');
+        }
+
+        return $objForm->jumpTo;
+    }
+
+    /**
      * Get a form field by a given name
      *
      * @param string $strName The form field name


### PR DESCRIPTION
Quite often I have to redirect after the form has been submitted. Up to now, I had to create a custom field in my module to set the jumpto page. but this option is already available in the generated form. but there is no way getting this information with haste.

I have added this function. Maybe it helps :)