### PR TITLE
Errors added by a custom validator are ignored

### DIFF
--- a/library/Haste/Form/Form.php
+++ b/library/Haste/Form/Form.php
@@ -864,6 +864,11 @@ class Form extends \Controller
                 if (!$objWidget->hasErrors() && $this->objModel !== null) {
                     $this->objModel->$strName =  $varValue;
                 }
+
+                // Re-check the status in case a custom validator has added an error
+                if ($objWidget->hasErrors()) {
+                    $this->blnValid = false;
+                }
             }
         }
 


### PR DESCRIPTION
If a custom validator does not throw an exception but adds an error via `$objWidget->addError()` instead, the form validation status is not adjusted accordingly.