### PR TITLE
Pass a real DCA object to the save callbacks

### DIFF
--- a/library/Haste/Form/Form.php
+++ b/library/Haste/Form/Form.php
@@ -424,14 +424,15 @@ class Form extends \Controller
                         $strTable = $objModel->getTable();
                     }
 
-                    $dc = (object) array(
-                        'id'            => $intId,
-                        'table'         => $strTable,
-                        'value'         => $varValue,
-                        'field'         => $strName,
-                        'inputName'     => $objWidget->name,
-                        'activeRecord'  => $objModel
-                    );
+                    \Controller::loadDataContainer($strTable);
+
+                    $dc = new \DC_Table($strTable);
+                    $dc->id = $intId;
+                    $dc->table = $strTable;
+                    $dc->value = $varValue;
+                    $dc->field = $strName;
+                    $dc->inputName = $objWidget->name;
+                    $dc->activeRecord = $objModel;
 
                     foreach ($arrDca['save_callback'] as $callback) {
                         if (is_array($callback)) {


### PR DESCRIPTION
This will prevent "Argument 2 passed to … must be an instance of Contao\DataContainer, instance of stdClass given" exceptions if the save callback has a type hint for a DataContainer object.