### PR TITLE
Changed \String::* calls to \StringUtil for PHP7 compatibility reasons

### DIFF
--- a/library/Haste/Util/StringUtil.php
+++ b/library/Haste/Util/StringUtil.php
@@ -44,7 +44,7 @@ class StringUtil
 
         // PHP 7 compatibility
         // See #309 (https://github.com/contao/core-bundle/issues/309)
-        if (version_compare('3.5.5', VERSION, '>=')) {
+        if (version_compare('3.5.5', VERSION . '.' . BUILD, '>=')) {
             // Must decode, tokens could be encoded
             $strText = \StringUtil::decodeEntities($strText);
         } else {
@@ -64,7 +64,7 @@ class StringUtil
 
         // PHP 7 compatibility
         // See #309 (https://github.com/contao/core-bundle/issues/309)
-        if (version_compare('3.5.5', VERSION, '>=')) {
+        if (version_compare('3.5.5', VERSION . '.' . BUILD, '>=')) {
             // first parse the tokens as they might have if-else clauses
             $strBuffer = \StringUtil::parseSimpleTokens($strText, $arrTokens);
         } else {
@@ -84,7 +84,7 @@ class StringUtil
 
         // PHP 7 compatibility
         // See #309 (https://github.com/contao/core-bundle/issues/309)
-        if (version_compare('3.5.5', VERSION, '>=')) {
+        if (version_compare('3.5.5', VERSION . '.' . BUILD, '>=')) {
             $strBuffer = \StringUtil::restoreBasicEntities($strBuffer);
         } else {
             $strBuffer = \String::restoreBasicEntities($strBuffer);

--- a/library/Haste/Util/StringUtil.php
+++ b/library/Haste/Util/StringUtil.php
@@ -42,8 +42,15 @@ class StringUtil
             $arrTokens = static::convertToText($arrTokens, $intTextFlags);
         }
 
-        // Must decode, tokens could be encoded
-        $strText = \String::decodeEntities($strText);
+        // PHP 7 compatibility
+        // See #309 (https://github.com/contao/core-bundle/issues/309)
+        if (version_compare('3.5.5', VERSION, '>=')) {
+            // Must decode, tokens could be encoded
+            $strText = \StringUtil::decodeEntities($strText);
+        } else {
+            // Must decode, tokens could be encoded
+            $strText = \String::decodeEntities($strText);
+        }
 
         // Replace all opening and closing tags with a hash so they don't get stripped
         // by parseSimpleTokens() - this is useful e.g. for XML content
@@ -55,8 +62,15 @@ class StringUtil
 
         $strText = str_replace($arrOriginal, $arrReplacement, $strText);
 
-        // first parse the tokens as they might have if-else clauses
-        $strBuffer = \String::parseSimpleTokens($strText, $arrTokens);
+        // PHP 7 compatibility
+        // See #309 (https://github.com/contao/core-bundle/issues/309)
+        if (version_compare('3.5.5', VERSION, '>=')) {
+            // first parse the tokens as they might have if-else clauses
+            $strBuffer = \StringUtil::parseSimpleTokens($strText, $arrTokens);
+        } else {
+            // first parse the tokens as they might have if-else clauses
+            $strBuffer = \String::parseSimpleTokens($strText, $arrTokens);
+        }
 
         $strBuffer = str_replace($arrReplacement, $arrOriginal, $strBuffer);
 
@@ -68,7 +82,13 @@ class StringUtil
             $strBuffer = static::recursiveReplaceTokensAndTags($strBuffer, $arrTokens, $intTextFlags);
         }
 
-        $strBuffer = \String::restoreBasicEntities($strBuffer);
+        // PHP 7 compatibility
+        // See #309 (https://github.com/contao/core-bundle/issues/309)
+        if (version_compare('3.5.5', VERSION, '>=')) {
+            $strBuffer = \StringUtil::restoreBasicEntities($strBuffer);
+        } else {
+            $strBuffer = \String::restoreBasicEntities($strBuffer);
+        }
 
         if ($intTextFlags > 0) {
             $strBuffer = static::convertToText($strBuffer, $intTextFlags);

--- a/library/Haste/Util/StringUtil.php
+++ b/library/Haste/Util/StringUtil.php
@@ -44,7 +44,7 @@ class StringUtil
 
         // PHP 7 compatibility
         // See #309 (https://github.com/contao/core-bundle/issues/309)
-        if (version_compare('3.5.5', VERSION . '.' . BUILD, '>=')) {
+        if (version_compare(VERSION . '.' . BUILD, '3.5.5', '>=')) {
             // Must decode, tokens could be encoded
             $strText = \StringUtil::decodeEntities($strText);
         } else {
@@ -64,7 +64,7 @@ class StringUtil
 
         // PHP 7 compatibility
         // See #309 (https://github.com/contao/core-bundle/issues/309)
-        if (version_compare('3.5.5', VERSION . '.' . BUILD, '>=')) {
+        if (version_compare(VERSION . '.' . BUILD, '3.5.5', '>=')) {
             // first parse the tokens as they might have if-else clauses
             $strBuffer = \StringUtil::parseSimpleTokens($strText, $arrTokens);
         } else {
@@ -84,7 +84,7 @@ class StringUtil
 
         // PHP 7 compatibility
         // See #309 (https://github.com/contao/core-bundle/issues/309)
-        if (version_compare('3.5.5', VERSION . '.' . BUILD, '>=')) {
+        if (version_compare(VERSION . '.' . BUILD, '3.5.5', '>=')) {
             $strBuffer = \StringUtil::restoreBasicEntities($strBuffer);
         } else {
             $strBuffer = \String::restoreBasicEntities($strBuffer);


### PR DESCRIPTION
PHP 7 compatibility - see contao/core-bundle#309.