### PR TITLE
Add a css class to form widget to identify a specific field

### DIFF
--- a/library/Haste/Form/Form.php
+++ b/library/Haste/Form/Form.php
@@ -796,6 +796,8 @@ class Form extends \Controller
                 $this->blnHasUploads = true;
             }
 
+            $objWidget->class = 'field-'. $strName;
+
             $this->arrWidgets[$strName] = $objWidget;
             $i++;
         }


### PR DESCRIPTION
Tested and needed in my environment.
Do we have to ```standardize()``` ```$strName```? I don't think so.