### PR TITLE
Add default value support for Input::get and Input::post

### DIFF
--- a/library/Haste/Input/Input.php
+++ b/library/Haste/Input/Input.php
@@ -16,6 +16,80 @@ class Input extends \Input
 {
 
     /**
+     * Return a $_GET variable or a default value
+     *
+     * @param string $strKey            The variable name
+     * @param mixed  $varDefaultValue   The default value
+     * @param bool   $blnDecodeEntities If true, all entities will be decoded
+     * @param bool   $blnKeepUnused     If true, the parameter will not be marked as used (see #4277)
+     *
+     * @return null
+     */
+    public static function get($strKey, $varDefaultValue=null, $blnDecodeEntities=false, $blnKeepUnused=false)
+    {
+        return parent::get($strKey, $blnDecodeEntities, $blnKeepUnused) ?: $varDefaultValue;
+    }
+
+
+    /**
+     * Return a $_POST variable or a default value
+     *
+     * @param string  $strKey            The variable name
+     * @param mixed   $varDefaultValue   The default value
+     * @param boolean $blnDecodeEntities If true, all entities will be decoded
+     *
+     * @return mixed The cleaned variable value
+     */
+    public static function post($strKey, $varDefaultValue=null, $blnDecodeEntities=false)
+    {
+        return parent::post($strKey, $blnDecodeEntities) ?: $varDefaultValue;
+    }
+
+
+    /**
+     * Return a $_POST variable preserving allowed HTML tags or a default value
+     *
+     * @param string  $strKey            The variable name
+     * @param mixed   $varDefaultValue   The default value
+     * @param boolean $blnDecodeEntities If true, all entities will be decoded
+     *
+     * @return mixed The cleaned variable value
+     */
+    public static function postHtml($strKey, $varDefaultValue=null, $blnDecodeEntities=false)
+    {
+        return parent::postHtml($strKey, $blnDecodeEntities) ?: $varDefaultValue;
+    }
+
+
+    /**
+     * Return a raw, unsafe $_POST variable or a default value
+     *
+     * @param string $strKey          The variable name
+     * @param mixed  $varDefaultValue The default value
+     *
+     * @return mixed The raw variable value
+     */
+    public static function postRaw($strKey, $varDefaultValue=null)
+    {
+        return parent::postRaw($strKey) ?: $varDefaultValue;
+    }
+
+
+    /**
+     * Return a raw, unsafe and unfiltered $_POST variable or a default value
+     *
+     * @param string $strKey          The variable name
+     * @param mixed  $varDefaultValue The default value
+     *
+     * @return mixed The raw variable value
+     */
+    public static function postUnsafeRaw($strKey, $varDefaultValue=null)
+    {
+        return parent::postUnsafeRaw($strKey) ?: $varDefaultValue;
+    }
+
+
+    /**
      * Check if auto_item is enabled and return $_GET variable
      *
      * @param string  $strKey            The variable name
@@ -37,4 +111,5 @@ class Input extends \Input
 
         return static::get($strKey, $blnDecodeEntities, $blnKeepUnused);
     }
+
 }


### PR DESCRIPTION
Now we can use 
```php
Input::get('key', 'defaultValue')
```
instead of 
```php 
Input::get('key') ?: 'defaultValue'
``` 

It's more readable when you use it directly as params like 
```php
Model::findByDate(Input::get('date', date('Y-m-d'))
```
instead of
```php
Model::findByDate(Input::get('date') ?: date('Y-m-d'))
```

I know this is a very little change but i use this very often and get confused from the syntax.