### PR TITLE
Make table options configurable instead of forcing a default

### DIFF
--- a/docs/Model/index.md
+++ b/docs/Model/index.md
@@ -21,7 +21,7 @@ $GLOBALS['TL_DCA']['tl_table_one']['fields']['my_field']['relation'] = array
     'type' => 'haste-ManyToMany',
     'load' => 'lazy',
     'table' => 'tl_table_two', // the related table,
-    'tableSql' => 'DEFAULT CHARSET=binary COLLATE binary ENGINE=MyISAM' // related table options (optional)
+    'tableSql' => 'DEFAULT CHARSET=big5 COLLATE big5_chinese_ci ENGINE=MyISAM' // related table options (optional)
     'reference' => 'id', // current table field (optional)
     'referenceSql' => "int(10) unsigned NOT NULL default '0'", // current table field sql definition (optional)
     'referenceColumn' => 'my_reference_field', // a custom column name in relation table (optional)

--- a/docs/Model/index.md
+++ b/docs/Model/index.md
@@ -20,7 +20,8 @@ $GLOBALS['TL_DCA']['tl_table_one']['fields']['my_field']['relation'] = array
 (
     'type' => 'haste-ManyToMany',
     'load' => 'lazy',
-    'table' => 'tl_table_two', // the related table
+    'table' => 'tl_table_two', // the related table,
+    'tableSql' => 'DEFAULT CHARSET=binary COLLATE binary ENGINE=MyISAM' // related table options (optional)
     'reference' => 'id', // current table field (optional)
     'referenceSql' => "int(10) unsigned NOT NULL default '0'", // current table field sql definition (optional)
     'referenceColumn' => 'my_reference_field', // a custom column name in relation table (optional)
@@ -28,7 +29,7 @@ $GLOBALS['TL_DCA']['tl_table_one']['fields']['my_field']['relation'] = array
     'fieldSql' => "int(10) unsigned NOT NULL default '0'", // related table field sql definition (optional)
     'fieldColumn' => 'my_related_field', // a custom column name in relation table (optional)
     'relationTable' => '', // custom relation table name (optional)
-    'forceSave' => true // false by default. If set to true it does not only store the values in the relation tables but also the "my_relation" field
+    'forceSave' => true, // false by default. If set to true it does not only store the values in the relation tables but also the "my_relation" field
     'bidirectional' => true // false by default. If set to true relations are handled bidirectional (e.g. project A is related to project B but project B is also related to project A)
 );
 ```

--- a/library/Haste/Model/Relations.php
+++ b/library/Haste/Model/Relations.php
@@ -504,7 +504,6 @@ class Relations
 
                 $arrDefinitions[$arrRelation['table']]['TABLE_FIELDS'][$arrRelation['reference_field']] = "`" . $arrRelation['reference_field'] . "` " . $arrRelation['reference_sql'];
                 $arrDefinitions[$arrRelation['table']]['TABLE_FIELDS'][$arrRelation['related_field']] = "`" . $arrRelation['related_field'] . "` " . $arrRelation['related_sql'];
-                $arrDefinitions[$arrRelation['table']]['TABLE_OPTIONS'] = ' ENGINE=MyISAM  DEFAULT CHARSET=utf8';
 
                 // Add the index only if there is no other (avoid duplicate keys)
                 if (empty($arrDefinitions[$arrRelation['table']]['TABLE_CREATE_DEFINITIONS'])) {

--- a/library/Haste/Model/Relations.php
+++ b/library/Haste/Model/Relations.php
@@ -504,7 +504,9 @@ class Relations
 
                 $arrDefinitions[$arrRelation['table']]['TABLE_FIELDS'][$arrRelation['reference_field']] = "`" . $arrRelation['reference_field'] . "` " . $arrRelation['reference_sql'];
                 $arrDefinitions[$arrRelation['table']]['TABLE_FIELDS'][$arrRelation['related_field']] = "`" . $arrRelation['related_field'] . "` " . $arrRelation['related_sql'];
-
+                if ($arrRelation['related_tableSql']) {
+                    $arrDefinitions[$arrRelation['table']]['TABLE_OPTIONS'] = $arrRelation['related_tableSql'];
+                }
                 // Add the index only if there is no other (avoid duplicate keys)
                 if (empty($arrDefinitions[$arrRelation['table']]['TABLE_CREATE_DEFINITIONS'])) {
                     $arrDefinitions[$arrRelation['table']]['TABLE_CREATE_DEFINITIONS'][$arrRelation['reference_field'] . "_" . $arrRelation['related_field']] = "UNIQUE KEY `" . $arrRelation['reference_field'] . "_" . $arrRelation['related_field'] . "` (`" . $arrRelation['reference_field'] . "`, `" . $arrRelation['related_field'] . "`)";
@@ -701,6 +703,7 @@ class Relations
 
                     // Related table data
                     $varRelation['related_table'] = $arrField['table'];
+                    $varRelation['related_tableSql'] = $arrField['tableSql'];
                     $varRelation['related_field'] = isset($arrField['fieldColumn']) ? $arrField['fieldColumn'] : (str_replace('tl_', '', $arrField['table']) . '_' . $varRelation['field']);
                     $varRelation['related_sql'] = isset($arrField['fieldSql']) ? $arrField['fieldSql'] : "int(10) unsigned NOT NULL default '0'";
 


### PR DESCRIPTION
Haste sets the collation to MyISAM with character set UTF-8, which currently throws an exception on database update in my setup ('utf8mb4_unicode_ci' is not valid for CHARACTER SET 'utf8'). Imo the collation should not be forced to MyISAM in the first place and this line could be dropped. :-)