### PR TITLE
Follow singleton pattern for DcaExtractor

### DIFF
--- a/library/Haste/Generator/ModelData.php
+++ b/library/Haste/Generator/ModelData.php
@@ -36,7 +36,7 @@ class ModelData
         }
 
         $strTable = $objModel->getTable();
-        $objDca = new \DcaExtractor($strTable);
+        $objDca = \DcaExtractor::getInstance($strTable);
         $arrRelations = $objDca->getRelations();
         $arrData = array();
 


### PR DESCRIPTION
Hello there,

while working with Haste I stumbled upon a tiny issue in the ModelData class. It instantiated a new DcaExtractor object rather than getting an instance via getInstance. DcaExtractors constructor is private, hence a fatal error when using this class.

Cheerio