### PR TITLE
Allow to specify php date/time expression to {{formatted_datetime}}

### DIFF
--- a/docs/Util/InsertTags.md
+++ b/docs/Util/InsertTags.md
@@ -20,7 +20,8 @@ See the [Contao documentation][flags] for available flags.
 
 ### Date and time formatting
 
-The `formatted_datetime` insert tag allows to format a timestamp
+The `formatted_datetime` insert tag allows to format a timestamp or a
+PHP date/time format (see http://php.net/manual/en/function.strtotime.php)
 using either the internal date/time formatting settings or a custom
 format.
 
@@ -38,6 +39,14 @@ format.
 
  4. `{{formatted_datetime::1234::datim}}`
  	Formats the timestamp `1234` to the system's date + time format.
+
+ 5. `{{formatted_datetime::+1 day::datim}}`
+ 	Formats the timestamp of `now +1 day` to the system's date + time format.
+
+ 6. `{{formatted_datetime::+1 week 2 days 4 hours 2 seconds::d.m.Y}}`
+ 	Formats the timestamp  of `now +1 week 2 days 4 hours 2 seconds` to Day.Month.Year.
+  	Available formatting options can be found in the [PHP `date` method][date].
+
 
 
 ### Date and time converting

--- a/library/Haste/Util/InsertTag.php
+++ b/library/Haste/Util/InsertTag.php
@@ -143,7 +143,7 @@ class InsertTag
     /**
      * Replace {{formatted_datetime::*}} insert tag
      *
-     * 4 possible use cases:
+     * 5 possible use cases:
      *
      * {{formatted_datetime::timestamp}}
      *      or
@@ -151,6 +151,7 @@ class InsertTag
      * {{formatted_datetime::timestamp::date}}      - formats a given timestamp with the global date format
      * {{formatted_datetime::timestamp::time}}      - formats a given timestamp with the global time format
      * {{formatted_datetime::timestamp::Y-m-d H:i}} - formats a given timestamp with the specified format
+     * {{formatted_datetime::+1 day::Y-m-d H:i}}    - formats a given php date/time format (see http://php.net/manual/en/function.strtotime.php) with the specified format
      *
      * @param array $arrTag
      *
@@ -159,6 +160,12 @@ class InsertTag
     private function replaceFormattedDateTime($arrTag)
     {
         $intTimestamp = $arrTag[1];
+
+        // Support strtotime()
+        if (!is_numeric($intTimestamp)) {
+            $intTimestamp = strtotime($intTimestamp);
+        }
+
         $strFormat = $arrTag[2];
 
         // Fallback


### PR DESCRIPTION
Extends the `{{formatted_datetime}}` insert tag so that you cannot just format a given timestamp but also have the timestamp taken form a php date/time expression.

Endless possiblities here then.