### PR TITLE
Compatibility with MS Excel (Office 365)

### DIFF
--- a/library/Haste/IO/Writer/CsvFileWriter.php
+++ b/library/Haste/IO/Writer/CsvFileWriter.php
@@ -25,7 +25,7 @@ class CsvFileWriter extends AbstractFileWriter
      * Delimiter character
      * @var string
      */
-    protected $strDelimiter = ',';
+    protected $strDelimiter = ';';
 
     /**
      * Enclosure character
@@ -109,7 +109,9 @@ class CsvFileWriter extends AbstractFileWriter
         if (!is_array($arrData)) {
             return false;
         }
-
+        
+        fprintf($this->resFile, chr(0xEF).chr(0xBB).chr(0xBF));
+        
         return (bool) fputcsv($this->resFile, $arrData, $this->strDelimiter, $this->strEnclosure);
     }
 


### PR DESCRIPTION
* Excel recognizes the individual columns with the semicolon as separator.
* The line fprintf($df, chr(0xEF).chr(0xBB).chr(0xBF)); writes file header for correct encoding (UTF8)
(Source: https://stackoverflow.com/a/21988713)