### PR TITLE
Pass DataContainer to getAttributesFromDca

### DIFF
--- a/library/Haste/Form/Form.php
+++ b/library/Haste/Form/Form.php
@@ -485,7 +485,7 @@ class Form extends \Controller
             $strTable = $objModel->getTable();
             \Contao\Controller::loadDataContainer($strTable);
             $dataContainer = '\Contao\DC_' . $GLOBALS['TL_DCA'][$strTable]['config']['dataContainer'];
-            $objDca = new $dataContainer($objModel->getTable());
+            $objDca = new $dataContainer($strTable);
             $objDca->id = $objModel->id;
             $objDca->activeRecord = $objModel;
         }

--- a/library/Haste/Form/Form.php
+++ b/library/Haste/Form/Form.php
@@ -482,10 +482,12 @@ class Form extends \Controller
         $strTable = '';
 
         if (null !== ($objModel = $this->getBoundModel())) {
-            $objDca = new \Contao\DC_Table($objModel->getTable());
+            $strTable = $objModel->getTable();
+            \Contao\Controller::loadDataContainer($strTable);
+            $dataContainer = '\Contao\DC_' . $GLOBALS['TL_DCA'][$strTable]['config']['dataContainer'];
+            $objDca = new $dataContainer($objModel->getTable());
             $objDca->id = $objModel->id;
             $objDca->activeRecord = $objModel;
-            $strTable = $objModel->getTable();
         }
 
         $arrDca = $strClass::getAttributesFromDca($arrDca, $arrDca['name'], $arrDca['value'], $strName, $strTable, $objDca);

--- a/library/Haste/Form/Form.php
+++ b/library/Haste/Form/Form.php
@@ -486,7 +486,7 @@ class Form extends \Controller
             \Contao\Controller::loadDataContainer($strTable);
 
             if (isset($GLOBALS['TL_DCA'][$strTable]) && isset($GLOBALS['TL_DCA'][$strTable]['config']['dataContainer'])) {
-                $dataContainer = '\Contao\DC_' . $GLOBALS['TL_DCA'][$strTable]['config']['dataContainer'];
+                $dataContainer = '\DC_' . $GLOBALS['TL_DCA'][$strTable]['config']['dataContainer'];
                 $objDca = new $dataContainer($strTable);
                 $objDca->id = $objModel->id;
                 $objDca->activeRecord = $objModel;

--- a/library/Haste/Form/Form.php
+++ b/library/Haste/Form/Form.php
@@ -478,7 +478,17 @@ class Form extends \Controller
             );
         }
 
-        $arrDca = $strClass::getAttributesFromDca($arrDca, $arrDca['name'], $arrDca['value']);
+        $objDca = null;
+        $strTable = '';
+
+        if (null !== ($objModel = $this->getBoundModel())) {
+            $objDca = new \Contao\DC_Table($objModel->getTable());
+            $objDca->id = $objModel->id;
+            $objDca->activeRecord = $objModel;
+            $strTable = $objModel->getTable();
+        }
+
+        $arrDca = $strClass::getAttributesFromDca($arrDca, $arrDca['name'], $arrDca['value'], $strName, $strTable, $objDca);
 
         // Convert optgroups so they work with FormSelectMenu
         if (is_array($arrDca['options']) && array_is_assoc($arrDca['options'])) {

--- a/library/Haste/Form/Form.php
+++ b/library/Haste/Form/Form.php
@@ -484,10 +484,13 @@ class Form extends \Controller
         if (null !== ($objModel = $this->getBoundModel())) {
             $strTable = $objModel->getTable();
             \Contao\Controller::loadDataContainer($strTable);
-            $dataContainer = '\Contao\DC_' . $GLOBALS['TL_DCA'][$strTable]['config']['dataContainer'];
-            $objDca = new $dataContainer($strTable);
-            $objDca->id = $objModel->id;
-            $objDca->activeRecord = $objModel;
+
+            if (isset($GLOBALS['TL_DCA'][$strTable]) && isset($GLOBALS['TL_DCA'][$strTable]['config']['dataContainer'])) {
+                $dataContainer = '\Contao\DC_' . $GLOBALS['TL_DCA'][$strTable]['config']['dataContainer'];
+                $objDca = new $dataContainer($strTable);
+                $objDca->id = $objModel->id;
+                $objDca->activeRecord = $objModel;
+            }
         }
 
         $arrDca = $strClass::getAttributesFromDca($arrDca, $arrDca['name'], $arrDca['value'], $strName, $strTable, $objDca);


### PR DESCRIPTION
I have a DCA with a `pid` relation to a parent table. I am using `addFieldsFromDca` of `Haste\Form\Form` to render form fields of the DCA fields in the front end. However, one of those fields has an `options_callback` where, depending on the `pid`, different options are shown to the user.

I still need this callback in the front end, as I want to show the user the correct options. However, no `DataContainer` will be passed to that callback in the front end.

Similar to the `save_callback`, we could pass a mock DCA object here as well, when there is a model binding present. What do you think?