### PR TITLE
Fix type error

### DIFF
--- a/library/Haste/Form/Form.php
+++ b/library/Haste/Form/Form.php
@@ -12,6 +12,7 @@
 
 namespace Haste\Form;
 
+use Contao\FrontendTemplate;
 use Haste\Form\Validator\ValidatorInterface;
 use Haste\Generator\RowClass;
 use Haste\Util\ArrayPosition;
@@ -949,11 +950,11 @@ class Form extends \Controller
     /**
      * Add form to a template
      *
-     * @param \FrontendTemplate $objTemplate
+     * @param FrontendTemplate $objTemplate
      *
      * @return $this
      */
-    public function addToTemplate(\FrontendTemplate $objTemplate)
+    public function addToTemplate(FrontendTemplate $objTemplate)
     {
         return $this->addToObject($objTemplate);
     }


### PR DESCRIPTION
 richardhj/contao-newsletter2go-sync#6 reports the following type error:

> Type error: Argument 1 passed to Haste\Form\Form::addToTemplate() must be an instance of FrontendTemplate, instance of Contao\FrontendTemplate given, called in /www/htdocs/w01915e7/beate-meier.ch/vendor/richardhj/contao-newsletter2go-sync/src/Dca/Newsletter2GoUser.php on line 149

We have had this kind of issue in other extensions as well 😄 