### PR TITLE
Fix version edit url for ajax toggle operation

### DIFF
--- a/library/Haste/Dca/AjaxOperations.php
+++ b/library/Haste/Dca/AjaxOperations.php
@@ -306,7 +306,13 @@ class AjaxOperations
         return (array) $hasteAjaxOperationSettings['options'];
     }
 
-    private function getVersionEditUrl(int $id, string $operation)
+    /**
+     * @param int    $id
+     * @param string $operation
+     *
+     * @return string|null
+     */
+    private function getVersionEditUrl($id, $operation)
     {
         if ($operation !== 'toggle') {
             return null;

--- a/library/Haste/Dca/AjaxOperations.php
+++ b/library/Haste/Dca/AjaxOperations.php
@@ -64,8 +64,8 @@ class AjaxOperations
 
         // Initialize versioning
         $versions = new \Versions($dc->table, $id);
-        $versions->initialize();
         $versions->setEditUrl($this->getVerionEditUrl((int)$id, (string)$operation));
+        $versions->initialize();
 
         // Determine next value and icon
         $options = $this->getOptions($hasteAjaxOperationSettings);
@@ -100,7 +100,7 @@ class AjaxOperations
                 TL_GENERAL
             );
         }
-        
+
         $response = array(
             'nextValue' => $options[$nextIndex]['value'],
             'nextIcon'  => $options[$nextIndex]['icon']

--- a/library/Haste/Dca/AjaxOperations.php
+++ b/library/Haste/Dca/AjaxOperations.php
@@ -12,6 +12,7 @@
 
 
 namespace Haste\Dca;
+use Contao\Environment;
 use Haste\Http\Response\JsonResponse;
 use Haste\Util\Debug;
 
@@ -64,6 +65,7 @@ class AjaxOperations
         // Initialize versioning
         $versions = new \Versions($dc->table, $id);
         $versions->initialize();
+        $versions->setEditUrl($this->getVerionEditUrl((int)$id, (string)$operation));
 
         // Determine next value and icon
         $options = $this->getOptions($hasteAjaxOperationSettings);
@@ -302,5 +304,17 @@ class AjaxOperations
     private function getOptions(array $hasteAjaxOperationSettings)
     {
         return (array) $hasteAjaxOperationSettings['options'];
+    }
+
+    private function getVerionEditUrl(int $id, string $operation)
+    {
+        if ($operation !== 'toggle') {
+            return null;
+        }
+
+        $url = Environment::get('request');
+        $url = preg_replace('/&(amp;)?id=[^&]+/', '', $url);
+        $url .= sprintf('&act=edit&id=%s', $id);
+        return $url;
     }
 }

--- a/library/Haste/Dca/AjaxOperations.php
+++ b/library/Haste/Dca/AjaxOperations.php
@@ -64,7 +64,7 @@ class AjaxOperations
 
         // Initialize versioning
         $versions = new \Versions($dc->table, $id);
-        $versions->setEditUrl($this->getVerionEditUrl((int)$id, (string)$operation));
+        $versions->setEditUrl($this->getVersionEditUrl((int)$id, (string)$operation));
         $versions->initialize();
 
         // Determine next value and icon
@@ -306,7 +306,7 @@ class AjaxOperations
         return (array) $hasteAjaxOperationSettings['options'];
     }
 
-    private function getVerionEditUrl(int $id, string $operation)
+    private function getVersionEditUrl(int $id, string $operation)
     {
         if ($operation !== 'toggle') {
             return null;


### PR DESCRIPTION
Unfortunately the version edit url is not correct while using ajax toggle.
I was not sure if other operations are handled as well with the AjaxOperations, because of that I added the check `$operation !== 'toggle'` - maybe that is not neccesary...