### PR TITLE
Fix checkFormFieldNameIsValid

### DIFF
--- a/library/Haste/Form/Form.php
+++ b/library/Haste/Form/Form.php
@@ -1127,7 +1127,7 @@ class Form extends \Controller
             throw new \InvalidArgumentException('You cannot use a numeric form field name.');
         }
 
-        if (in_array($strName, $this->arrFormFields, true)) {
+        if (in_array($strName, array_keys($this->arrFormFields), true)) {
             throw new \InvalidArgumentException(sprintf('"%s" has already been added to the form.', $strName));
         }
     }


### PR DESCRIPTION
Currently the second check in `Form::checkFormFieldNameIsValid` will never be true, because it checks the name against the array content of `$this->arrFormFields` (which is the widget data) rather than the array keys, which are the actual form field names. So when doing

```php
$form->addFormField('foo', […]);

$form->addFormField('foo', […]);
```

the latter simply overwrites the former without any error.