### PR TITLE
Reset a form field's ID to the field name

### DIFF
--- a/library/Haste/Form/Form.php
+++ b/library/Haste/Form/Form.php
@@ -487,6 +487,9 @@ class Form extends \Controller
 
         $arrDca = $strClass::getAttributesFromDca($arrDca, $arrDca['name'], $arrDca['value'], $strName, $dc->table, $dc);
 
+        // Reset the ID to the field name
+        $arrDca['id'] = $strName;
+
         // Remove the label if it was not set – Contao will set it to field name if it's not present
         if (!isset($strLabel) || !$strLabel) {
             $arrDca['label'] = '';


### PR DESCRIPTION
`\Contao\Widget::getAttributesFromDca` will set the ID and the name of the form element to the same value. However, this makes it impossible to do something like this:

```php
$form = new Form('foobar', 'GET', function(Form $form) use ($request) {
    return null !== $request && $request->query->has('submit');
});

$form->addFormField('foo1', [
    'inputType' => 'select', 
    'name' => 'foo[]',
    'options' => [
        'option1',
        'option2',
    ],
    'value' => $request->query->get('foo')[0],
]);

$form->addFormField('foo2', [
    'inputType' => 'select', 
    'name' => 'foo[]',
    'options' => [
        'option3',
        'option4',
    ],
    'value' => $request->query->get('foo')[1],
]);
```

i.e. grouped form elements with `[]`. Without the change invalid HTML would be generated, as both selects would have the ID `ctrl_foo[]`. 

With the proposed change the ID will be `ctrl_foo1` and `ctrl_foo2` while the name attribute will stay at `foo[]`.