### PR TITLE
Fix undo related issues

### DIFF
--- a/library/Haste/Util/Undo.php
+++ b/library/Haste/Util/Undo.php
@@ -109,6 +109,10 @@ class Undo
                     }
                 }
 
+                if (empty($GLOBALS['HASTE_HOOKS']['undoData']) || empty($hasteData)) {
+                    continue;
+                }
+
                 $insertId = $objInsertStmt->insertId;
 
                 foreach ($GLOBALS['HASTE_HOOKS']['undoData'] as $callback) {

--- a/library/Haste/Util/Undo.php
+++ b/library/Haste/Util/Undo.php
@@ -102,6 +102,7 @@ class Undo
                 }
 
                 // Trigger the undo_callback
+                \Controller::loadDataContainer($table);
                 if (is_array($GLOBALS['TL_DCA'][$table]['config']['onundo_callback'])) {
                     foreach ($GLOBALS['TL_DCA'][$table]['config']['onundo_callback'] as $callback) {
                         if (is_array($callback)) {

--- a/library/Haste/Util/Undo.php
+++ b/library/Haste/Util/Undo.php
@@ -58,10 +58,6 @@ class Undo
             $GLOBALS['HASTE_HOOKS']['undoData'] = array_merge($GLOBALS['HASTE_HOOKS']['undoData'], $GLOBALS['TL_HOOKS']['hasteUndoData']);
         }
 
-        if (empty($GLOBALS['HASTE_HOOKS']['undoData']) || !static::hasData($intUndoId)) {
-            return false;
-        }
-
         $objRecords = \Database::getInstance()->prepare("SELECT * FROM tl_undo WHERE id=?")
                                               ->limit(1)
                                               ->execute($intUndoId);


### PR DESCRIPTION
Haste replaces the default undo behaviour of the `DC_Table` if any `haste_data` exist in the undo record. This pull request solves two issues:

1. As it replaces the default behaviour it has to be executed even if no haste related hooks are registered. Imagine an undo record containing data of an removed extension. The `hasData()` check is superfluous here, because it's already checked before replacing the default behaviour.

2. The `onundo_callback` was very likely not triggered because the related data container wasn't loaded.

I wonder why haste replaces the default behaviour and not just using the onundo_callback to execute it's extended features. This might be an additional change. I stick the current implementation here.