### PR TITLE
PHP8 compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ nbproject/
 # Composer
 /vendor/
 /composer.lock
+
+# PHPUnit
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,12 @@
         "contao-community-alliance/composer-plugin": "~2.4 || ~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.8.*",
+        "phpunit/phpunit": "^9.2",
         "phpoffice/phpexcel": "^1.6",
         "phpoffice/phpspreadsheet": "^1.6"
+    },
+    "scripts": {
+        "unit-tests": "vendor/bin/phpunit"
     },
     "replace": {
         "contao-legacy/haste": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "~5.6 || ~7.0",
+        "php": "~5.6 || ~7.0 || ~8.0",
         "contao/core-bundle": "^4.4",
         "contao-community-alliance/composer-plugin": "~2.4 || ~3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "~5.6 || ~7.0 || ~8.0",
+        "php": "~7.0 || ~8.0",
         "contao/core-bundle": "^4.4",
         "contao-community-alliance/composer-plugin": "~2.4 || ~3.0"
     },

--- a/library/Haste/Dca/AjaxOperations.php
+++ b/library/Haste/Dca/AjaxOperations.php
@@ -186,7 +186,7 @@ class AjaxOperations
     {
         $hasPermission = true;
 
-        if ($GLOBALS['TL_DCA'][$table]['fields'][$hasteAjaxOperationSettings['field']]['exclude']
+        if (($GLOBALS['TL_DCA'][$table]['fields'][$hasteAjaxOperationSettings['field']]['exclude'] ?? false)
             && !\BackendUser::getInstance()->hasAccess($table . '::' . $hasteAjaxOperationSettings['field'], 'alexf')
         ) {
 
@@ -220,7 +220,7 @@ class AjaxOperations
         $field = $hasteAjaxOperationSettings['field'];
 
         // Trigger the save_callback
-        if (is_array($GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['save_callback'])) {
+        if (is_array($GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['save_callback'] ?? null)) {
             foreach ($GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['save_callback'] as $callback) {
                 if (is_array($callback)) {
 

--- a/library/Haste/Dca/DateRangeFilter.php
+++ b/library/Haste/Dca/DateRangeFilter.php
@@ -41,7 +41,7 @@ class DateRangeFilter
 
         foreach ($GLOBALS['TL_DCA'][$strTable]['fields'] as $strField => $arrField) {
             if (!empty($arrField['rangeFilter'])
-                && in_array($arrField['eval']['rgxp'], array('date', 'time', 'datim'))
+                && in_array($arrField['eval']['rgxp'] ?? null, array('date', 'time', 'datim'))
             ) {
                 $this->arrFieldsToFilter[] = $strField;
             }
@@ -69,7 +69,7 @@ class DateRangeFilter
 
         $GLOBALS['TL_CSS'][] = 'system/modules/haste/assets/haste.css';
 
-        $filter = ($GLOBALS['TL_DCA'][$dc->table]['list']['sorting']['mode'] == 4) ? $dc->table.'_'.CURRENT_ID : $dc->table;
+        $filter = (($GLOBALS['TL_DCA'][$dc->table]['list']['sorting']['mode'] ?? null) == 4) ? $dc->table.'_'.CURRENT_ID : $dc->table;
         $session = \Session::getInstance()->getData();
 
         // Set filter from user input
@@ -101,19 +101,19 @@ class DateRangeFilter
             $return .= '<div class="tl_subpanel haste_dateRangeFilter">';
 
             $return .= sprintf('<strong>%s: </strong>',
-                $GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['label'][0]
+                $GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['label'][0] ?? ''
             );
 
             $return .= $this->createDatepickerInputField(
                 'haste_dateRangeFilter_' . $field . '_from',
                 $session['filter'][$filter][$key]['from'],
-                $GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['eval']['rgxp']
+                $GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['eval']['rgxp'] ?? ''
             );
 
             $return .= $this->createDatepickerInputField(
                 'haste_dateRangeFilter_' . $field . '_to',
                 $session['filter'][$filter][$key]['to'],
-                $GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['eval']['rgxp']
+                $GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['eval']['rgxp'] ?? ''
             );
 
             $return .= '</div>';
@@ -136,7 +136,7 @@ class DateRangeFilter
 
         foreach ($this->arrFieldsToFilter as $field) {
             $key = 'haste_dateRangeFilter_' . $field;
-            $rgxp = $GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['eval']['rgxp'];
+            $rgxp = $GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['eval']['rgxp'] ?? '';
 
             $from = ($session['filter'][$filter][$key]['from']) ?: null;
             $to = ($session['filter'][$filter][$key]['to']) ?: null;
@@ -307,14 +307,14 @@ class DateRangeFilter
             ($value) ? ' active' : '',
             $value,
             $icon,
-            specialchars($GLOBALS['TL_LANG']['MSC']['datepicker']),
+            specialchars($GLOBALS['TL_LANG']['MSC']['datepicker'] ?? ''),
             $name,
             $name,
             $name,
             $format,
             $time,
-            $GLOBALS['TL_LANG']['MSC']['weekOffset'],
-            $GLOBALS['TL_LANG']['MSC']['titleFormat']
+            $GLOBALS['TL_LANG']['MSC']['weekOffset'] ?? '',
+            $GLOBALS['TL_LANG']['MSC']['titleFormat'] ?? ''
         );
     }
 }

--- a/library/Haste/Form/Form.php
+++ b/library/Haste/Form/Form.php
@@ -635,7 +635,7 @@ class Form extends \Controller
         $this->loadDataContainer($strTable);
         $arrFields = &$GLOBALS['TL_DCA'][$strTable]['fields'];
 
-        foreach ($arrFields as $k => $v) {
+        foreach (($arrFields ?? []) as $k => $v) {
             if (is_callable($varCallback) && !call_user_func_array($varCallback, array(&$k, &$v))) {
                 continue;
             }
@@ -847,7 +847,7 @@ class Form extends \Controller
         // Initialize widgets
         foreach ($this->arrFormFields as $strName => $arrField) {
 
-            $strClass = $GLOBALS['TL_FFL'][$arrField['type']];
+            $strClass = $GLOBALS['TL_FFL'][$arrField['type']] ?? '';
 
             if (!class_exists($strClass)) {
                 throw new \RuntimeException(sprintf('The class "%s" for type "%s" could not be found.', $strClass, $arrField['type']));

--- a/library/Haste/Generator/ModelData.php
+++ b/library/Haste/Generator/ModelData.php
@@ -72,7 +72,7 @@ class ModelData
 
             $arrAdditional['formatted'] = Format::dcaValue($strTable, $strField, $varValue);
 
-            if (in_array($arrFields[$strField]['eval']['rgxp'], array('date', 'datim', 'time'))) {
+            if (in_array($arrFields[$strField]['eval']['rgxp'] ?? null, array('date', 'datim', 'time'))) {
                 $arrData[$strField] = new Timestamp($varValue, $strLabel, $arrAdditional);
             } else {
                 $arrData[$strField] = new Plain($varValue, $strLabel, $arrAdditional);

--- a/library/Haste/IO/Mapper/DcaFieldMapper.php
+++ b/library/Haste/IO/Mapper/DcaFieldMapper.php
@@ -26,11 +26,11 @@ class DcaFieldMapper extends ArrayMapper
      */
     public function __construct($strTable)
     {
-        if (!is_array($GLOBALS['TL_DCA'][$strTable])) {
+        if (!is_array($GLOBALS['TL_DCA'][$strTable] ?? null)) {
             \Controller::loadDataContainer($strTable);
         }
 
-        if (!is_array($GLOBALS['TL_DCA'][$strTable]['fields'])) {
+        if (!is_array($GLOBALS['TL_DCA'][$strTable]['fields'] ?? null)) {
             throw new \Exception('DCA for table "' . $strTable . '" does not have any fields.');
         }
 

--- a/library/Haste/Model/Relations.php
+++ b/library/Haste/Model/Relations.php
@@ -136,10 +136,10 @@ class Relations
         if ($arrRelation !== false) {
             $cacheKey = $arrRelation['table'] . $dc->activeRecord->{$arrRelation['reference']};
 
-            $field = $GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field];
+            $field = $GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field] ?? [];
 
             // Support for csv values
-            if ($field['eval']['multiple'] && $field['eval']['csv']) {
+            if (($field['eval']['multiple'] ?? false) && ($field['eval']['csv'] ?? false)) {
                 $arrValues = explode($field['eval']['csv'], $varValue);
             } else {
                 $arrValues = deserialize($varValue, true);
@@ -313,7 +313,7 @@ class Relations
         }
 
         foreach ($GLOBALS['TL_DCA'][$dc->table]['fields'] as $strField => $arrField) {
-            if ($arrField['eval']['doNotCopy']) {
+            if ($arrField['eval']['doNotCopy'] ?? false) {
                 continue;
             }
 
@@ -515,13 +515,13 @@ class Relations
         $arrIds = is_array($GLOBALS['TL_DCA'][$dc->table]['list']['sorting']['root']) ? $GLOBALS['TL_DCA'][$dc->table]['list']['sorting']['root'] : [];
 
         // Include the child records in tree view
-        if ($GLOBALS['TL_DCA'][$dc->table]['list']['sorting']['mode'] == 5 && count($arrIds) > 0) {
+        if (($GLOBALS['TL_DCA'][$dc->table]['list']['sorting']['mode'] ?? null) == 5 && count($arrIds) > 0) {
             $arrIds = \Database::getInstance()->getChildRecords($arrIds, $dc->table, false, $arrIds);
         }
 
         $blnFilter = false;
         $session = \Session::getInstance()->getData();
-        $filterId = ($GLOBALS['TL_DCA'][$dc->table]['list']['sorting']['mode'] == 4) ? $dc->table.'_'.CURRENT_ID : $dc->table;
+        $filterId = (($GLOBALS['TL_DCA'][$dc->table]['list']['sorting']['mode'] ?? null) == 4) ? $dc->table.'_'.CURRENT_ID : $dc->table;
 
         foreach (array_keys(static::$arrFilterableFields) as $field) {
             if (isset($session['filter'][$filterId][$field])) {
@@ -546,7 +546,7 @@ class Relations
             return;
         }
 
-        $arrIds = is_array($GLOBALS['TL_DCA'][$dc->table]['list']['sorting']['root']) ? $GLOBALS['TL_DCA'][$dc->table]['list']['sorting']['root'] : [];
+        $arrIds = is_array($GLOBALS['TL_DCA'][$dc->table]['list']['sorting']['root'] ?? null) ? $GLOBALS['TL_DCA'][$dc->table]['list']['sorting']['root'] : [];
         $blnFilter = false;
         $session = \Session::getInstance()->getData();
 
@@ -619,7 +619,7 @@ class Relations
             return '';
         }
 
-        $filter = ($GLOBALS['TL_DCA'][$dc->table]['list']['sorting']['mode'] == 4) ? $dc->table.'_'.CURRENT_ID : $dc->table;
+        $filter = (($GLOBALS['TL_DCA'][$dc->table]['list']['sorting']['mode'] ?? null) == 4) ? $dc->table.'_'.CURRENT_ID : $dc->table;
         $session = \Session::getInstance()->getData();
 
         // Set filter from user input
@@ -641,7 +641,7 @@ class Relations
 
         foreach (static::$arrFilterableFields as $field => $arrRelation) {
             $return .= '<select name="' . $field . '" class="tl_select' . (isset($session['filter'][$filter][$field]) ? ' active' : '') . '">
-    <option value="tl_' . $field . '">' . $GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['label'][0] . '</option>
+    <option value="tl_' . $field . '">' . ($GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['label'][0] ?? '') . '</option>
     <option value="tl_' . $field . '">---</option>';
 
             $arrIds = Model::getRelatedValues($arrRelation['reference_table'], $field);
@@ -664,14 +664,14 @@ class Relations
             $dc->field = $field;
 
             // Call the options_callback
-            if ((is_array($GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['options_callback']) || is_callable($GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['options_callback'])) && !$GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['reference']) {
-                if (is_array($GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['options_callback'])) {
+            if ((is_array($GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['options_callback'] ?? null) || is_callable($GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['options_callback'] ?? null)) && !($GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['reference'] ?? null)) {
+                if (is_array($GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['options_callback'] ?? null)) {
                     $strClass = $GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['options_callback'][0];
                     $strMethod = $GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['options_callback'][1];
 
                     $objClass = \System::importStatic($strClass);
                     $options_callback = $objClass->$strMethod($dc);
-                } elseif (is_callable($GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['options_callback'])) {
+                } elseif (is_callable($GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['options_callback'] ?? null)) {
                     $options_callback = $GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['options_callback']($dc);
                 }
 
@@ -706,9 +706,9 @@ class Relations
                 // Use reference array
                 if (isset($GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['reference'])) {
                     $option_label = is_array($GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['reference'][$vv]) ? $GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['reference'][$vv][0] : $GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['reference'][$vv];
-                } elseif ($GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['eval']['isAssociative'] || array_is_assoc($GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['options'])) {
+                } elseif (($GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['eval']['isAssociative'] ?? false) || array_is_assoc($GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['options'] ?? null)) {
                     // Associative array
-                    $option_label = $GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['options'][$vv];
+                    $option_label = $GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['options'][$vv] ?? '';
                 }
 
                 // No empty options allowed
@@ -801,7 +801,7 @@ class Relations
 
             $options_sorter = [];
             foreach ($relatedSearchFields as $relatedSearchField) {
-                $option_label = $GLOBALS['TL_DCA'][$relTable]['fields'][$relatedSearchField]['label'][0] ?: (\is_array($GLOBALS['TL_LANG']['MSC'][$relatedSearchField]) ? $GLOBALS['TL_LANG']['MSC'][$relatedSearchField][0] : $GLOBALS['TL_LANG']['MSC'][$relatedSearchField]);
+                $option_label = $GLOBALS['TL_DCA'][$relTable]['fields'][$relatedSearchField]['label'][0] ?: (\is_array($GLOBALS['TL_LANG']['MSC'][$relatedSearchField] ?? null) ? $GLOBALS['TL_LANG']['MSC'][$relatedSearchField][0] : ($GLOBALS['TL_LANG']['MSC'][$relatedSearchField] ?? ''));
                 $options_sorter[utf8_romanize($option_label).'_'.$relatedSearchField] = '  <option value="'.specialchars($relatedSearchField).'"'.(($relatedSearchField == $sessionValues[$dc->table]['searchField'] && $sessionValues[$dc->table]['table'] == $relTable) ? ' selected="selected"' : '').'>'.$option_label.'</option>';
             }
 

--- a/library/Haste/Util/Format.php
+++ b/library/Haste/Util/Format.php
@@ -67,7 +67,7 @@ class Format
     {
         \System::loadLanguageFile($strTable);
         \Controller::loadDataContainer($strTable);
-        $arrField = $GLOBALS['TL_DCA'][$strTable]['fields'][$strField];
+        $arrField = $GLOBALS['TL_DCA'][$strTable]['fields'][$strField] ?? [];
 
         // Add the "name" key (backwards compatibility)
         if (!isset($arrField['name'])) {
@@ -89,7 +89,7 @@ class Format
         if (!empty($arrField['label'])) {
             $strLabel = is_array($arrField['label']) ? $arrField['label'][0] : $arrField['label'];
         } else {
-            $strLabel = is_array($GLOBALS['TL_LANG']['MSC'][$arrField['name']]) ? $GLOBALS['TL_LANG']['MSC'][$arrField['name']][0] : $GLOBALS['TL_LANG']['MSC'][$arrField['name']];
+            $strLabel = is_array($GLOBALS['TL_LANG']['MSC'][$arrField['name']] ?? null) ? $GLOBALS['TL_LANG']['MSC'][$arrField['name']][0] : $GLOBALS['TL_LANG']['MSC'][$arrField['name']] ?? '';
         }
 
         if ($strLabel == '') {

--- a/library/Haste/Util/Undo.php
+++ b/library/Haste/Util/Undo.php
@@ -99,7 +99,7 @@ class Undo
 
                 // Trigger the undo_callback
                 \Controller::loadDataContainer($table);
-                if (is_array($GLOBALS['TL_DCA'][$table]['config']['onundo_callback'])) {
+                if (is_array($GLOBALS['TL_DCA'][$table]['config']['onundo_callback'] ?? null)) {
                     foreach ($GLOBALS['TL_DCA'][$table]['config']['onundo_callback'] as $callback) {
                         if (is_array($callback)) {
                             \System::importStatic($callback[0])->{$callback[1]}($table, $row, $dc);

--- a/tests/Haste/Test/DateTime/DateTimeTest.php
+++ b/tests/Haste/Test/DateTime/DateTimeTest.php
@@ -13,10 +13,11 @@
 namespace Haste\Test\DateTime;
 
 use Haste\DateTime\DateTime;
+use PHPUnit\Framework\TestCase;
 
 include_once __DIR__ . '/../../../../../library/Haste/DateTime/DateTime.php';
 
-class DateTimeTest extends \PHPUnit_Framework_TestCase
+class DateTimeTest extends TestCase
 {
     public function testCreateFromFormat()
     {

--- a/tests/Haste/Test/DateTime/ZodiacSignTest.php
+++ b/tests/Haste/Test/DateTime/ZodiacSignTest.php
@@ -12,8 +12,9 @@ namespace Haste\Test\DateTime;
 include_once __DIR__ . '/../../../../../library/Haste/DateTime/ZodiacSign.php';
 
 use Haste\DateTime\ZodiacSign;
+use PHPUnit\Framework\TestCase;
 
-class ZodiacSignTest extends \PHPUnit_Framework_TestCase
+class ZodiacSignTest extends TestCase
 {
 
     public function testLatins()

--- a/tests/Haste/Test/Form/FormTest.php
+++ b/tests/Haste/Test/Form/FormTest.php
@@ -12,12 +12,13 @@ namespace Haste\Test\Form;
 include_once __DIR__ . '/../../../../../library/Haste/Form/Form.php';
 
 use Haste\Form\Form;
+use PHPUnit\Framework\TestCase;
 
-class FormTest extends \PHPUnit_Framework_TestCase
+class FormTest extends TestCase
 {
     protected $instance = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->instance = new Form('someid', 'POST', function() {
             return true;

--- a/tests/Haste/Test/Generator/RowClassTest.php
+++ b/tests/Haste/Test/Generator/RowClassTest.php
@@ -12,8 +12,9 @@ namespace Haste\Test\Generator;
 include_once __DIR__ . '/../../../../../library/Haste/Generator/RowClass.php';
 
 use Haste\Generator\RowClass;
+use PHPUnit\Framework\TestCase;
 
-class RowClassTest extends \PHPUnit_Framework_TestCase
+class RowClassTest extends TestCase
 {
 
     public function testKey()

--- a/tests/Haste/Test/HasteTest.php
+++ b/tests/Haste/Test/HasteTest.php
@@ -9,10 +9,11 @@
 namespace Haste\Test;
 
 use Haste\Haste;
+use PHPUnit\Framework\TestCase;
 
 include_once __DIR__ . '/../../../../../../library/Haste.php';
 
-class HasteTest extends \PHPUnit_Framework_TestCase
+class HasteTest extends TestCase
 {
     public function testInstance()
     {

--- a/tests/Haste/Test/Http/ResponseTest.php
+++ b/tests/Haste/Test/Http/ResponseTest.php
@@ -34,34 +34,34 @@ class ResponseTest extends TestCase
     public function testRegularOutput()
     {
         $objResponse = new Response('Foobar');
-        $this->assertSame("HTTP/1.1 200 OK\nContent-Length: 6\nContent-Type: text/plain; charset=utf-8\n\nFoobar", (string) $objResponse);
+        $this->assertSame("HTTP/1.1 200 OK\nContent-Type: text/plain; charset=utf-8\n\nFoobar", (string) $objResponse);
     }
 
     public function testJsonOutput()
     {
         $objResponse = new JsonResponse(array('foo' => 'bar'), 201);
         $this->assertSame(201, $objResponse->getStatusCode());
-        $this->assertSame("HTTP/1.1 201 Created\nContent-Length: 13\nContent-Type: application/json; charset=utf-8\n\n{\"foo\":\"bar\"}", (string) $objResponse);
+        $this->assertSame("HTTP/1.1 201 Created\nContent-Type: application/json; charset=utf-8\n\n{\"foo\":\"bar\"}", (string) $objResponse);
     }
 
     public function testEmptyJsonOutput()
     {
         $objResponse = new JsonResponse(array());
-        $this->assertSame("HTTP/1.1 200 OK\nContent-Length: 2\nContent-Type: application/json; charset=utf-8\n\n[]", (string) $objResponse);
+        $this->assertSame("HTTP/1.1 200 OK\nContent-Type: application/json; charset=utf-8\n\n[]", (string) $objResponse);
     }
 
     public function testXmlOutput()
     {
         $objResponse = new XmlResponse('<foo><bar>indeed</bar></foo>', 304);
         $this->assertSame(304, $objResponse->getStatusCode());
-        $this->assertSame("HTTP/1.1 304 Not Modified\nContent-Length: 28\nContent-Type: application/xml; charset=utf-8\n\n<foo><bar>indeed</bar></foo>", (string) $objResponse);
+        $this->assertSame("HTTP/1.1 304 Not Modified\nContent-Type: application/xml; charset=utf-8\n\n<foo><bar>indeed</bar></foo>", (string) $objResponse);
     }
 
     public function testHtmlOutput()
     {
         $objResponse = new HtmlResponse('<!DOCTYPE html><html lang="en"><head></head><body></body></html>', 100);
         $this->assertSame(100, $objResponse->getStatusCode());
-        $this->assertSame((string) $objResponse, "HTTP/1.1 100 Continue\nContent-Length: 64\nContent-Type: text/html; charset=utf-8\n\n<!DOCTYPE html><html lang=\"en\"><head></head><body></body></html>");
+        $this->assertSame("HTTP/1.1 100 Continue\nContent-Type: text/html; charset=utf-8\n\n<!DOCTYPE html><html lang=\"en\"><head></head><body></body></html>", (string) $objResponse);
     }
 
     public function testSetStatusCode()

--- a/tests/Haste/Test/Http/ResponseTest.php
+++ b/tests/Haste/Test/Http/ResponseTest.php
@@ -13,8 +13,9 @@ use Haste\Http\Response\Response;
 use Haste\Http\Response\JsonResponse;
 use Haste\Http\Response\XmlResponse;
 use Haste\Http\Response\HtmlResponse;
+use PHPUnit\Framework\TestCase;
 
-class ResponseTest extends \PHPUnit_Framework_TestCase
+class ResponseTest extends TestCase
 {
     public function testInstance()
     {
@@ -71,12 +72,11 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(200, $objResponse->getStatusCode());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testSetStatusCodeException()
     {
         $objResponse = new Response('Foobar', 200);
+
+        $this->expectException(\InvalidArgumentException::class);
         $objResponse->setStatusCode(7000);
     }
 }

--- a/tests/Haste/Test/IO/CsvFileWriterTest.php
+++ b/tests/Haste/Test/IO/CsvFileWriterTest.php
@@ -18,16 +18,17 @@ include_once __DIR__ . '/../../../../../library/Haste/IO/Writer/CsvFileWriter.ph
 
 use Haste\IO\Reader\ArrayReader;
 use Haste\IO\Writer\CsvFileWriter;
+use PHPUnit\Framework\TestCase;
 
-class CsvFileWriterTest extends \PHPUnit_Framework_TestCase
+class CsvFileWriterTest extends TestCase
 {
     protected $tempFile;
 
-    public function setUp()
+    public function setUp(): void
     {
         $file = tempnam(sys_get_temp_dir(), '');
 
-        define(TL_ROOT, dirname($file));
+        define('TL_ROOT', dirname($file));
         $this->tempFile = basename($file);
     }
 

--- a/tests/Haste/Test/Number/BackendWidgetTest.php
+++ b/tests/Haste/Test/Number/BackendWidgetTest.php
@@ -6,8 +6,9 @@ namespace Haste\Test\Number;
 include_once __DIR__ . '/../../../../../library/Haste/Number/BackendWidget.php';
 
 use Haste\Number\BackendWidget;
+use PHPUnit\Framework\TestCase;
 
-class BackendWidgetTest extends \PHPUnit_Framework_TestCase
+class BackendWidgetTest extends TestCase
 {
     public function testInstance()
     {
@@ -18,10 +19,10 @@ class BackendWidgetTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider inputProvider
      */
-    public function testInput($input, $output, $exception=null)
+    public function testInput($input, $output, $expectException = false)
     {
-        if ($exception) {
-            $this->setExpectedException($exception);
+        if ($expectException) {
+            $this->expectException(\InvalidArgumentException::class);
         }
 
         \Input::setPost('test_number_field', $input);
@@ -38,8 +39,8 @@ class BackendWidgetTest extends \PHPUnit_Framework_TestCase
             array('0', 0),
             array('150', 1500000),
             array('-1', -10000),
-            array('foobar.00', 0, 'InvalidArgumentException'),
-            array('test', 0, 'InvalidArgumentException'),
+            array('foobar.00', 0, true),
+            array('test', 0, true),
         );
     }
 }

--- a/tests/Haste/Test/Number/NumberTest.php
+++ b/tests/Haste/Test/Number/NumberTest.php
@@ -5,8 +5,9 @@ namespace Haste\Test\Number;
 include_once __DIR__ . '/../../../../../library/Haste/Number/Number.php';
 
 use Haste\Number\Number;
+use PHPUnit\Framework\TestCase;
 
-class NumberTest extends \PHPUnit_Framework_TestCase
+class NumberTest extends TestCase
 {
     public function testInstance()
     {
@@ -134,10 +135,11 @@ class NumberTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider createExceptionProvider
-     * @expectedException \InvalidArgumentException
      */
     public function testCreateExceptions($data)
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         Number::create($data);
     }
 

--- a/tests/Haste/Test/Units/Mass/ScaleTest.php
+++ b/tests/Haste/Test/Units/Mass/ScaleTest.php
@@ -18,13 +18,14 @@ include_once __DIR__ . '/../../../../../../library/Haste/Units/Mass/Scale.php';
 use Haste\Units\Mass\Unit;
 use Haste\Units\Mass\Scale;
 use Haste\Units\Mass\Weight;
+use PHPUnit\Framework\TestCase;
 
-class ScaleTest extends \PHPUnit_Framework_TestCase
+class ScaleTest extends TestCase
 {
 
     protected $instance = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->instance = new Scale();
     }

--- a/tests/Haste/Test/Units/Mass/UnitTest.php
+++ b/tests/Haste/Test/Units/Mass/UnitTest.php
@@ -13,8 +13,9 @@ include_once __DIR__ . '/../../../../../../library/Haste/Units/Converter.php';
 include_once __DIR__ . '/../../../../../../library/Haste/Units/Mass/Unit.php';
 
 use Haste\Units\Mass\Unit;
+use PHPUnit\Framework\TestCase;
 
-class UnitTest extends \PHPUnit_Framework_TestCase
+class UnitTest extends TestCase
 {
 
     public function testBase()

--- a/tests/Haste/Test/Util/ArrayPositionTest.php
+++ b/tests/Haste/Test/Util/ArrayPositionTest.php
@@ -15,9 +15,10 @@ namespace Haste\Test\Util;
 include_once __DIR__ . '/../../../../../library/Haste/Util/ArrayPosition.php';
 
 use Haste\Util\ArrayPosition;
+use PHPUnit\Framework\TestCase;
 
 
-class ArrayPositionTest extends \PHPUnit_Framework_TestCase
+class ArrayPositionTest extends TestCase
 {
 
     public function testFirst()

--- a/tests/Haste/Test/Util/RepositoryVersionTest.php
+++ b/tests/Haste/Test/Util/RepositoryVersionTest.php
@@ -15,8 +15,9 @@ namespace Haste\Test\Util;
 include_once __DIR__ . '/../../../../../library/Haste/Util/RepositoryVersion.php';
 
 use Haste\Util\RepositoryVersion;
+use PHPUnit\Framework\TestCase;
 
-class RepositoryVersionTest extends \PHPUnit_Framework_TestCase
+class RepositoryVersionTest extends TestCase
 {
 
     /**

--- a/tests/Haste/Test/Util/StringUtilTest.php
+++ b/tests/Haste/Test/Util/StringUtilTest.php
@@ -15,11 +15,12 @@ namespace Haste\Test\Util;
 include_once __DIR__ . '/../../../../../library/Haste/Util/StringUtil.php';
 
 use Haste\Util\StringUtil;
+use PHPUnit\Framework\TestCase;
 
 include_once __DIR__ . '/../../../../../library/Haste/Util/StringUtil.php';
 
 
-class StringUtilTest extends \PHPUnit_Framework_TestCase
+class StringUtilTest extends TestCase
 {
 
     /**

--- a/tests/Haste/Test/Util/UrlTest.php
+++ b/tests/Haste/Test/Util/UrlTest.php
@@ -15,8 +15,9 @@ namespace Haste\Test\Util;
 include_once __DIR__ . '/../../../../../library/Haste/Util/Url.php';
 
 use Haste\Util\Url;
+use PHPUnit\Framework\TestCase;
 
-class UrlTest extends \PHPUnit_Framework_TestCase
+class UrlTest extends TestCase
 {
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -84,12 +84,12 @@ class Controller
     {
         // I am a dummy
     }
-    public function generateFrontendUrl($strName)
+    public static function generateFrontendUrl($strName)
     {
         return $strName;
     }
 
-    public function replaceInsertTags($strText)
+    public static function replaceInsertTags($strText)
     {
         return $strText;
     }


### PR DESCRIPTION
This is a first attempt at gaining PHP8 support.

* I had to raise the PHPUnit version and adjust the tests (changes in 07043c8 must have failed before IMHO).
* I also dropped support for PHP5.6 (no actively supported Contao version runs on this version anymore). This allows use of the null coalescing operator.
* I tried to spot as many array access problems as I could find in a first run. 100% sure there are still more things in there but I hope it's a valuable start. This will probably need patching over time as soon as errors occur. 

There are quite a lot of deprecated things in the codebase (esp with Contao >= 4.9 in mind) or things that could be optimized. I did not touch any of these things in this PR (and do not intend to). :slightly_smiling_face: 