### PR TITLE
Don't use global namespaced Contao classes

### DIFF
--- a/config/upgrade.php
+++ b/config/upgrade.php
@@ -49,12 +49,12 @@ if (!class_exists(HasteUpdater::class)) {
                     $newTable = $relation['table'];
 
                     // Rename the table
-                    if ($oldTable !== $newTable && \Database::getInstance()->tableExists($oldTable, null, true)) {
-                        if (\Database::getInstance()->tableExists($newTable, null, true)) {
-                            \System::log("Haste updater: Could not rename $oldTable to $newTable automatically because $newTable already exists! You have to migrate the data manually!", __METHOD__, TL_ERROR);
+                    if ($oldTable !== $newTable && \Contao\Database::getInstance()->tableExists($oldTable, null, true)) {
+                        if (\Contao\Database::getInstance()->tableExists($newTable, null, true)) {
+                            \Contao\System::log("Haste updater: Could not rename $oldTable to $newTable automatically because $newTable already exists! You have to migrate the data manually!", __METHOD__, TL_ERROR);
                         } else {
-                            \Database::getInstance()->query("RENAME TABLE $oldTable TO $newTable");
-                            \System::log("Haste updater: renamed relations table $oldTable to $newTable", __METHOD__, TL_GENERAL);
+                            \Contao\Database::getInstance()->query("RENAME TABLE $oldTable TO $newTable");
+                            \Contao\System::log("Haste updater: renamed relations table $oldTable to $newTable", __METHOD__, TL_GENERAL);
                         }
                     }
                 }
@@ -68,8 +68,8 @@ if (!class_exists(HasteUpdater::class)) {
         {
             $tables = [];
 
-            if (!method_exists(\System::class, 'getContainer')) {
-                foreach (\ModuleLoader::getActive() as $module) {
+            if (!method_exists(\Contao\System::class, 'getContainer')) {
+                foreach (\Contao\ModuleLoader::getActive() as $module) {
                     $dir = TL_ROOT.'/system/modules/'.$module.'/dca';
 
                     if (!is_dir($dir)) {
@@ -85,7 +85,7 @@ if (!class_exists(HasteUpdater::class)) {
                     }
                 }
             } else {
-                $files = System::getContainer()
+                $files = \Contao\System::getContainer()
                     ->get('contao.resource_finder')
                     ->findIn('dca')
                     ->depth(0)
@@ -99,7 +99,7 @@ if (!class_exists(HasteUpdater::class)) {
             }
 
             foreach (array_unique($tables) as $table) {
-                \Controller::loadDataContainer($table);
+                \Contao\Controller::loadDataContainer($table);
             }
         }
     }

--- a/library/Haste/Data/Relation.php
+++ b/library/Haste/Data/Relation.php
@@ -12,13 +12,14 @@
 
 namespace Haste\Data;
 
+use Contao\Model;
 use Haste\Generator\ModelData;
 
 
 class Relation extends \ArrayObject
 {
 
-    public function __construct(\Model $objModel=null, $label='', array $additional=array(), $varCallable=null)
+    public function __construct(Model $objModel=null, $label='', array $additional=array(), $varCallable=null)
     {
         if ($label != '' && !isset($additional['label'])) {
             $additional['label'] = $label;

--- a/library/Haste/DateTime/ZodiacSign.php
+++ b/library/Haste/DateTime/ZodiacSign.php
@@ -12,6 +12,8 @@
 
 namespace Haste\DateTime;
 
+use Contao\System;
+
 class ZodiacSign
 {
 
@@ -76,7 +78,7 @@ class ZodiacSign
      */
     public function getLabel()
     {
-        \System::loadLanguageFile('zodiacsigns');
+        System::loadLanguageFile('zodiacsigns');
 
         $strKey = $this->getLatin();
 

--- a/library/Haste/Dca/DateRangeFilter.php
+++ b/library/Haste/Dca/DateRangeFilter.php
@@ -12,6 +12,12 @@
 
 namespace Haste\Dca;
 
+use Contao\Database;
+use Contao\DataContainer;
+use Contao\Date;
+use Contao\Session;
+use Contao\Validator;
+
 class DateRangeFilter
 {
     /**
@@ -57,7 +63,7 @@ class DateRangeFilter
     /**
      * Adds the filters to the panel
      *
-     * @param \DataContainer $dc
+     * @param DataContainer $dc
      *
      * @return string
      */
@@ -70,7 +76,7 @@ class DateRangeFilter
         $GLOBALS['TL_CSS'][] = 'system/modules/haste/assets/haste.css';
 
         $filter = (($GLOBALS['TL_DCA'][$dc->table]['list']['sorting']['mode'] ?? null) == 4) ? $dc->table.'_'.CURRENT_ID : $dc->table;
-        $session = \Session::getInstance()->getData();
+        $session = Session::getInstance()->getData();
 
         // Set filter from user input
         if ('tl_filters' === \Input::post('FORM_SUBMIT')) {
@@ -90,7 +96,7 @@ class DateRangeFilter
                 }
             }
 
-            \Session::getInstance()->setData($session);
+            Session::getInstance()->setData($session);
         }
 
         $return = '';
@@ -125,12 +131,12 @@ class DateRangeFilter
     /**
      * Filters the records by setting sorting->root if filters are set
      *
-     * @param \DataContainer $dc
+     * @param DataContainer $dc
      */
     public function filterRecords($dc)
     {
         $filter = ($GLOBALS['TL_DCA'][$dc->table]['list']['sorting']['mode'] == 4) ? $dc->table.'_'.CURRENT_ID : $dc->table;
-        $session = \Session::getInstance()->getData();
+        $session = Session::getInstance()->getData();
         $root = array();
         $blnDoFilter = false;
 
@@ -186,7 +192,7 @@ class DateRangeFilter
     /**
      * Fetch valid records within from->to range
      *
-     * @param \DataContainer $dc
+     * @param DataContainer $dc
      * @param string         $field
      * @param int            $from
      * @param int            $to
@@ -215,7 +221,7 @@ class DateRangeFilter
             implode(' AND ', $where)
         );
 
-        return \Database::getInstance()->query($sql)->fetchEach('id');
+        return Database::getInstance()->query($sql)->fetchEach('id');
     }
 
     /**
@@ -232,7 +238,7 @@ class DateRangeFilter
         // Validate first
         $method = 'is' . ucfirst($rgxp);
 
-        if (!\Validator::$method($value)) {
+        if (!Validator::$method($value)) {
             return null;
         }
 
@@ -266,7 +272,7 @@ class DateRangeFilter
     private function createDatepickerInputField($name, $value, $rgxp)
     {
         $icon = 'assets/datepicker/images/icon.svg';
-        $format = \Date::formatToJs($GLOBALS['TL_CONFIG'][$rgxp . 'Format']);
+        $format = Date::formatToJs($GLOBALS['TL_CONFIG'][$rgxp . 'Format']);
 
         if (version_compare(VERSION, '4.2', '<')) {
             $icon = sprintf('assets/mootools/datepicker/%s/icon.gif', $GLOBALS['TL_ASSETS']['DATEPICKER']);

--- a/library/Haste/EventListener/AjaxReloadListener.php
+++ b/library/Haste/EventListener/AjaxReloadListener.php
@@ -5,7 +5,6 @@ namespace Haste\EventListener;
 use Contao\ContentModel;
 use Contao\Environment;
 use Contao\ModuleModel;
-use Contao\Template;
 use Haste\Ajax\ReloadHelper;
 use Haste\Util\Debug;
 

--- a/library/Haste/Form/Validator/MandatoryOn.php
+++ b/library/Haste/Form/Validator/MandatoryOn.php
@@ -2,7 +2,7 @@
 
 namespace Haste\Form\Validator;
 
-
+use Contao\Widget;
 use Haste\Form\Form;
 
 class MandatoryOn implements ValidatorInterface
@@ -29,7 +29,7 @@ class MandatoryOn implements ValidatorInterface
      * Validates a widget
      *
      * @param mixed   $varValue Widget value
-     * @param \Widget $objWidget
+     * @param Widget  $objWidget
      * @param Form    $objForm
      *
      * @return mixed Widget value
@@ -55,4 +55,4 @@ class MandatoryOn implements ValidatorInterface
 
         return $varValue;
     }
-} 
+}

--- a/library/Haste/Form/Validator/ValidatorInterface.php
+++ b/library/Haste/Form/Validator/ValidatorInterface.php
@@ -12,6 +12,7 @@
 
 namespace Haste\Form\Validator;
 
+use Contao\Widget;
 
 interface ValidatorInterface
 {
@@ -19,11 +20,11 @@ interface ValidatorInterface
      * Validates a widget
      *
      * @param mixed            $varValue Widget value
-     * @param \Widget          $objWidget
+     * @param Widget           $objWidget
      * @param \Haste\Form\Form $objForm
      *
      * @return mixed Widget value
      * @todo Add type hinting to the method parameters (in 5.0, as it would break the Interface)
      */
     public function validate($varValue, $objWidget, $objForm);
-} 
+}

--- a/library/Haste/Generator/ModelData.php
+++ b/library/Haste/Generator/ModelData.php
@@ -12,7 +12,10 @@
 
 namespace Haste\Generator;
 
-use Haste\Haste;
+use Contao\Controller;
+use Contao\DcaExtractor;
+use Contao\Model;
+use Contao\System;
 use Haste\Data\Collection;
 use Haste\Data\Plain;
 use Haste\Data\Relation;
@@ -25,23 +28,23 @@ class ModelData
 
     /**
      * Auto-format model data based on DCA config
-     * @param   \Model
+     * @param   Model
      * @param   callable
      * @return  \ArrayObject
      */
-    public static function generate(\Model $objModel=null, $varCallable=null)
+    public static function generate(Model $objModel=null, $varCallable=null)
     {
         if (null === $objModel) {
             return new \ArrayObject(array(), \ArrayObject::ARRAY_AS_PROPS);
         }
 
         $strTable = $objModel->getTable();
-        $objDca = \DcaExtractor::getInstance($strTable);
+        $objDca = DcaExtractor::getInstance($strTable);
         $arrRelations = $objDca->getRelations();
         $arrData = array();
 
-        \System::loadLanguageFile($strTable);
-        \Controller::loadDataContainer($strTable);
+        System::loadLanguageFile($strTable);
+        Controller::loadDataContainer($strTable);
 
         $arrFields = &$GLOBALS['TL_DCA'][$strTable]['fields'];
 
@@ -56,7 +59,7 @@ class ModelData
 
                 if ($objRelated == null) {
                     $arrData[$strField] = new Plain('', $strLabel, $arrAdditional);
-                } elseif ($objRelated instanceof \Model\Collection) {
+                } elseif ($objRelated instanceof Model\Collection) {
                     $arrCollection = array();
                     foreach ($objRelated as $objRelatedModel) {
                         $arrCollection[] = new Relation($objRelatedModel, '', array(), $varCallable);
@@ -88,11 +91,11 @@ class ModelData
 
     /**
      * Generate tokens for model data
-     * @param   \Model
+     * @param   Model
      * @param   callable
      * @return  array
      */
-    public static function generateTokens(\Model $objModel=null, $varCallable=null)
+    public static function generateTokens(Model $objModel=null, $varCallable=null)
     {
         $objData = static::generate($objModel, $varCallable);
 

--- a/library/Haste/Generator/RowClass.php
+++ b/library/Haste/Generator/RowClass.php
@@ -12,6 +12,8 @@
 
 namespace Haste\Generator;
 
+use Contao\FormPassword;
+
 class RowClass
 {
 
@@ -152,7 +154,7 @@ class RowClass
             }
 
             // Increase total before generating class to prevent "last" on the first input field
-            if (!$hasColumns && $varValue instanceof \FormPassword) {
+            if (!$hasColumns && $varValue instanceof FormPassword) {
                 ++$total;
             }
 
@@ -165,7 +167,7 @@ class RowClass
             elseif (is_object($varValue))
             {
                 // Generate class on confirmation field
-                if (!$hasColumns && $varValue instanceof \FormPassword) {
+                if (!$hasColumns && $varValue instanceof FormPassword) {
                     ++$current;
                     $varValue->rowClassConfirm = $this->generateClass($current, $total, $k);
                 }

--- a/library/Haste/Geodesy/Datum/WGS84.php
+++ b/library/Haste/Geodesy/Datum/WGS84.php
@@ -14,6 +14,9 @@
 namespace Haste\Geodesy\Datum;
 
 
+use Contao\Request;
+use Contao\System;
+
 class WGS84 implements GeodeticDatum
 {
 
@@ -79,12 +82,12 @@ class WGS84 implements GeodeticDatum
         $strAddress = urlencode($strAddress);
 
         // Get the coordinates
-        $objRequest = new \Request();
+        $objRequest = new Request();
         $objRequest->send('http://maps.googleapis.com/maps/api/geocode/json?address=' . $strAddress . '&sensor=false');
 
         // Request failed
         if ($objRequest->hasError()) {
-            \System::log('Could not get coordinates for: ' . $strAddress . ' (' . $objRequest->response . ')', __METHOD__, TL_ERROR);
+            System::log('Could not get coordinates for: ' . $strAddress . ' (' . $objRequest->response . ')', __METHOD__, TL_ERROR);
 
             return null;
         }

--- a/library/Haste/Haste.php
+++ b/library/Haste/Haste.php
@@ -12,7 +12,10 @@
 
 namespace Haste;
 
-class Haste extends \Controller
+use Contao\Controller;
+use Contao\Files;
+
+class Haste extends Controller
 {
     /**
      * Current object instance (Singleton)
@@ -70,7 +73,7 @@ class Haste extends \Controller
 
             // Does not matter if file or directory
             if (!file_exists(TL_ROOT . '/' . $strDirectory)) {
-                if (!\Files::getInstance()->mkdir($strDirectory)) {
+                if (!Files::getInstance()->mkdir($strDirectory)) {
                     return false;
                 }
             }

--- a/library/Haste/IO/Mapper/DcaFieldMapper.php
+++ b/library/Haste/IO/Mapper/DcaFieldMapper.php
@@ -12,7 +12,7 @@
 
 namespace Haste\IO\Mapper;
 
-use Haste\Haste;
+use Contao\Controller;
 
 class DcaFieldMapper extends ArrayMapper
 {
@@ -27,7 +27,7 @@ class DcaFieldMapper extends ArrayMapper
     public function __construct($strTable)
     {
         if (!is_array($GLOBALS['TL_DCA'][$strTable] ?? null)) {
-            \Controller::loadDataContainer($strTable);
+            Controller::loadDataContainer($strTable);
         }
 
         if (!is_array($GLOBALS['TL_DCA'][$strTable]['fields'] ?? null)) {

--- a/library/Haste/IO/Reader/DatabaseResultReader.php
+++ b/library/Haste/IO/Reader/DatabaseResultReader.php
@@ -12,6 +12,8 @@
 
 namespace Haste\IO\Reader;
 
+use Database\Result;
+
 class DatabaseResultReader implements HeaderFieldsInterface, \Iterator
 {
 
@@ -37,7 +39,7 @@ class DatabaseResultReader implements HeaderFieldsInterface, \Iterator
      * Initialize the object
      * @param object
      */
-    public function __construct(\Database\Result $objResult)
+    public function __construct(Result $objResult)
     {
         $this->objResult = $objResult;
         $this->blnValid = ($this->objResult->numRows > 0);

--- a/library/Haste/IO/Reader/ModelCollectionReader.php
+++ b/library/Haste/IO/Reader/ModelCollectionReader.php
@@ -12,6 +12,8 @@
 
 namespace Haste\IO\Reader;
 
+use Model\Collection;
+
 class ModelCollectionReader implements HeaderFieldsInterface, \Iterator
 {
 
@@ -37,7 +39,7 @@ class ModelCollectionReader implements HeaderFieldsInterface, \Iterator
      * Initialize the object
      * @param object
      */
-    public function __construct(\Model\Collection $objCollection)
+    public function __construct(Collection $objCollection)
     {
         $this->objCollection = $objCollection;
         $this->blnValid = ($this->objCollection->numRows > 0);

--- a/library/Haste/IO/Writer/ModelWriter.php
+++ b/library/Haste/IO/Writer/ModelWriter.php
@@ -12,6 +12,8 @@
 
 namespace Haste\IO\Writer;
 
+use Contao\Model;
+
 class ModelWriter extends AbstractWriter
 {
 
@@ -56,7 +58,7 @@ class ModelWriter extends AbstractWriter
             return false;
         }
 
-        /** @type \Model $objModel */
+        /** @type Model $objModel */
         $objModel = new $this->strModel();
         $objModel->setRow($arrData);
         $objModel->save();

--- a/library/Haste/Input/Input.php
+++ b/library/Haste/Input/Input.php
@@ -12,7 +12,7 @@
 
 namespace Haste\Input;
 
-class Input extends \Input
+class Input extends \Contao\Input
 {
 
     /**

--- a/library/Haste/Model/Model.php
+++ b/library/Haste/Model/Model.php
@@ -12,7 +12,9 @@
 
 namespace Haste\Model;
 
-abstract class Model extends \Model
+use Contao\Database;
+
+abstract class Model extends \Contao\Model
 {
 
     /**
@@ -38,7 +40,7 @@ abstract class Model extends \Model
 
         if ($arrRelation !== false) {
 
-            /** @type \Model $strClass */
+            /** @type \Contao\Model $strClass */
             $strClass = static::getClassFromTable($arrRelation['related_table']);
 
             if (class_exists($strClass)) {
@@ -98,8 +100,8 @@ abstract class Model extends \Model
         $strOrder = "";
 
         // Preserve the values order by using the force saved values in the table in the ORDER BY statement
-        if (count($arrValues) == 1 && $arrRelation['forceSave'] && \Database::getInstance()->fieldExists($strField, $arrRelation['related_table'])) {
-            $objRecord = \Database::getInstance()->prepare("SELECT " . $strField . " FROM " . $arrRelation['related_table'] . " WHERE " . $arrRelation['field'] . "=?")
+        if (count($arrValues) == 1 && $arrRelation['forceSave'] && Database::getInstance()->fieldExists($strField, $arrRelation['related_table'])) {
+            $objRecord = Database::getInstance()->prepare("SELECT " . $strField . " FROM " . $arrRelation['related_table'] . " WHERE " . $arrRelation['field'] . "=?")
                 ->limit(1)
                 ->execute($arrValues[0]);
 
@@ -109,10 +111,10 @@ abstract class Model extends \Model
                 $arrRecordValues = array(0);
             }
 
-            $strOrder = " ORDER BY " . \Database::getInstance()->findInSet($arrRelation['reference_field'], $arrRecordValues);
+            $strOrder = " ORDER BY " . Database::getInstance()->findInSet($arrRelation['reference_field'], $arrRecordValues);
         }
 
-        return \Database::getInstance()->prepare("SELECT " . $arrRelation['reference_field'] . " FROM " . $arrRelation['table'] . (!empty($arrValues) ? (" WHERE " . $arrRelation['related_field'] . " IN ('" . implode("','", $arrValues) . "')") : "") . $strOrder)
+        return Database::getInstance()->prepare("SELECT " . $arrRelation['reference_field'] . " FROM " . $arrRelation['table'] . (!empty($arrValues) ? (" WHERE " . $arrRelation['related_field'] . " IN ('" . implode("','", $arrValues) . "')") : "") . $strOrder)
                                        ->execute()
                                        ->fetchEach($arrRelation['reference_field']);
     }
@@ -140,8 +142,8 @@ abstract class Model extends \Model
         $strOrder = "";
 
         // Preserve the values order by using the force saved values in the table in the ORDER BY statement
-        if (count($arrValues) == 1 && $arrRelation['forceSave'] && \Database::getInstance()->fieldExists($strField, $arrRelation['reference_table'])) {
-            $objRecord = \Database::getInstance()->prepare("SELECT " . $strField . " FROM " . $arrRelation['reference_table'] . " WHERE " . $arrRelation['reference'] . "=?")
+        if (count($arrValues) == 1 && $arrRelation['forceSave'] && Database::getInstance()->fieldExists($strField, $arrRelation['reference_table'])) {
+            $objRecord = Database::getInstance()->prepare("SELECT " . $strField . " FROM " . $arrRelation['reference_table'] . " WHERE " . $arrRelation['reference'] . "=?")
                 ->limit(1)
                 ->execute($arrValues[0]);
 
@@ -151,10 +153,10 @@ abstract class Model extends \Model
                 $arrRecordValues = array(0);
             }
 
-            $strOrder = " ORDER BY " . \Database::getInstance()->findInSet($arrRelation['related_field'], $arrRecordValues);
+            $strOrder = " ORDER BY " . Database::getInstance()->findInSet($arrRelation['related_field'], $arrRecordValues);
         }
 
-        return \Database::getInstance()->prepare("SELECT " . $arrRelation['related_field'] . " FROM " . $arrRelation['table'] . (!empty($arrValues) ? (" WHERE " . $arrRelation['reference_field'] . " IN ('" . implode("','", $arrValues) . "')") : "") . $strOrder)
+        return Database::getInstance()->prepare("SELECT " . $arrRelation['related_field'] . " FROM " . $arrRelation['table'] . (!empty($arrValues) ? (" WHERE " . $arrRelation['reference_field'] . " IN ('" . implode("','", $arrValues) . "')") : "") . $strOrder)
                                        ->execute()
                                        ->fetchEach($arrRelation['related_field']);
     }
@@ -189,7 +191,7 @@ abstract class Model extends \Model
                 $arrRelation['related_field'] => $varValue,
             );
 
-            \Database::getInstance()->prepare("INSERT INTO " . $arrRelation['table'] . " %s")
+            Database::getInstance()->prepare("INSERT INTO " . $arrRelation['table'] . " %s")
                 ->set($arrSet)
                 ->execute();
         }
@@ -212,10 +214,10 @@ abstract class Model extends \Model
             throw new \Exception('Field ' . $strField . ' does not seem to be related!');
         }
 
-        \Database::getInstance()->prepare("DELETE FROM " . $arrRelation['table'] . " WHERE " . $arrRelation['reference_field'] . "=?")
+        Database::getInstance()->prepare("DELETE FROM " . $arrRelation['table'] . " WHERE " . $arrRelation['reference_field'] . "=?")
             ->execute($varReference);
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -228,16 +230,16 @@ abstract class Model extends \Model
                 $arrValues[$strField] = $this->$strField;
             }
         }
-        
+
         parent::save();
-        
+
         foreach($arrValues as $strField => $arrValue) {
             // Check if $arrValue is an array. Otherwise don't change the relation table.
             if (is_array($arrValue)) {
                 static::setRelatedValues(static::$strTable, $strField, $this->id, $arrValue);
             }
         }
-        
+
         return $this;
     }
 }

--- a/library/Haste/Number/BackendWidget.php
+++ b/library/Haste/Number/BackendWidget.php
@@ -12,11 +12,13 @@
 
 namespace Haste\Number;
 
+use Contao\TextField;
+
 /**
  * Class BackendWidget
  * Provide methods to handle Number input.
  */
-class BackendWidget extends \TextField
+class BackendWidget extends TextField
 {
 
     /**

--- a/library/Haste/Util/FileUpload.php
+++ b/library/Haste/Util/FileUpload.php
@@ -2,7 +2,10 @@
 
 namespace Haste\Util;
 
-class FileUpload extends \FileUpload
+use Contao\Message;
+use Contao\System;
+
+class FileUpload extends \Contao\FileUpload
 {
 
     /**
@@ -286,8 +289,8 @@ class FileUpload extends \FileUpload
 
             foreach ($files as $k => $file) {
                 if (!$file['error'] && $file['size'] < $this->minFileSize) {
-                    \Message::addError(sprintf($GLOBALS['TL_LANG']['ERR']['minFileSize'], $minlength_kb_readable));
-                    \System::log('File "'.$file['name'].'" exceeds the minimum file size of '.$minlength_kb_readable, __METHOD__, TL_ERROR);
+                    Message::addError(sprintf($GLOBALS['TL_LANG']['ERR']['minFileSize'], $minlength_kb_readable));
+                    System::log('File "'.$file['name'].'" exceeds the minimum file size of '.$minlength_kb_readable, __METHOD__, TL_ERROR);
                     $this->blnHasError = true;
                     unset($files[$k]);
                 }

--- a/library/Haste/Util/Format.php
+++ b/library/Haste/Util/Format.php
@@ -12,7 +12,10 @@
 
 namespace Haste\Util;
 
-use Haste\Haste;
+use Contao\Controller;
+use Contao\Database;
+use Contao\DataContainer;
+use Contao\System;
 
 class Format
 {
@@ -26,7 +29,7 @@ class Format
     {
         $strFormat = isset($GLOBALS['objPage']) ? $GLOBALS['objPage']->dateFormat : $GLOBALS['TL_CONFIG']['dateFormat'];
 
-        return \System::parseDate($strFormat, $intTstamp);
+        return System::parseDate($strFormat, $intTstamp);
     }
 
 
@@ -39,7 +42,7 @@ class Format
     {
         $strFormat = isset($GLOBALS['objPage']) ? $GLOBALS['objPage']->timeFormat : $GLOBALS['TL_CONFIG']['timeFormat'];
 
-        return \System::parseDate($strFormat, $intTstamp);
+        return System::parseDate($strFormat, $intTstamp);
     }
 
 
@@ -52,7 +55,7 @@ class Format
     {
         $strFormat = isset($GLOBALS['objPage']) ? $GLOBALS['objPage']->datimFormat : $GLOBALS['TL_CONFIG']['datimFormat'];
 
-        return \System::parseDate($strFormat, $intTstamp);
+        return System::parseDate($strFormat, $intTstamp);
     }
 
     /**
@@ -65,8 +68,8 @@ class Format
      */
     public static function dcaLabel($strTable, $strField)
     {
-        \System::loadLanguageFile($strTable);
-        \Controller::loadDataContainer($strTable);
+        System::loadLanguageFile($strTable);
+        Controller::loadDataContainer($strTable);
         $arrField = $GLOBALS['TL_DCA'][$strTable]['fields'][$strField] ?? [];
 
         // Add the "name" key (backwards compatibility)
@@ -105,14 +108,14 @@ class Format
      * @param string              $strTable
      * @param string              $strField
      * @param mixed               $varValue
-     * @param \DataContainer|null $objDc
+     * @param DataContainer|null $objDc
      *
      * @return mixed
      */
-    public static function dcaValue($strTable, $strField, $varValue, \DataContainer $objDc = null)
+    public static function dcaValue($strTable, $strField, $varValue, DataContainer $objDc = null)
     {
-        \System::loadLanguageFile($strTable);
-        \Controller::loadDataContainer($strTable);
+        System::loadLanguageFile($strTable);
+        Controller::loadDataContainer($strTable);
         $arrField = $GLOBALS['TL_DCA'][$strTable]['fields'][$strField];
 
         // Add the "name" key (backwards compatibility)
@@ -128,25 +131,25 @@ class Format
      *
      * @param array               $arrField
      * @param                     $varValue
-     * @param \DataContainer|null $objDc
+     * @param DataContainer|null $objDc
      *
      * @return mixed
      */
-    public static function dcaValueFromArray(array $arrField, $varValue, \DataContainer $objDc = null)
+    public static function dcaValueFromArray(array $arrField, $varValue, DataContainer $objDc = null)
     {
         $varValue = deserialize($varValue);
 
         if (is_array($arrField['options_callback']) && $objDc !== null) { // Options callback (array)
 
             $arrCallback = $arrField['options_callback'];
-            $arrField['options'] = \System::importStatic($arrCallback[0])->{$arrCallback[1]}($objDc);
+            $arrField['options'] = System::importStatic($arrCallback[0])->{$arrCallback[1]}($objDc);
 
         } elseif (is_callable($arrField['options_callback']) && $objDc !== null) { // Options callback (callable)
             $arrField['options'] = $arrField['options_callback']($objDc);
 
         } elseif (isset($arrField['foreignKey']) && $varValue) { // foreignKey
             $chunks = explode('.', $arrField['foreignKey'], 2);
-            $objOptions = \Database::getInstance()->query("SELECT id, " . $chunks[1] . " AS value FROM " . $chunks[0] . " WHERE id IN (" . implode(',', array_map('intval', (array) $varValue)) . ")");
+            $objOptions = Database::getInstance()->query("SELECT id, " . $chunks[1] . " AS value FROM " . $chunks[0] . " WHERE id IN (" . implode(',', array_map('intval', (array) $varValue)) . ")");
             $arrField['options'] = array();
 
             while ($objOptions->next()) {

--- a/library/Haste/Util/InsertTag.php
+++ b/library/Haste/Util/InsertTag.php
@@ -12,7 +12,10 @@
 
 namespace Haste\Util;
 
-use Haste\Haste;
+use Contao\Config;
+use Contao\Controller;
+use Contao\Date;
+use Contao\FormFieldModel;
 
 class InsertTag
 {
@@ -36,7 +39,7 @@ class InsertTag
             return $varValue;
         }
 
-        return \Controller::replaceInsertTags($varValue, false);
+        return Controller::replaceInsertTags($varValue, false);
     }
 
 
@@ -112,12 +115,12 @@ class InsertTag
         }
 
         try {
-            $date = new \Date($chunks[1], $this->determineFormat($chunks[2]));
+            $date = new Date($chunks[1], $this->determineFormat($chunks[2]));
         } catch (\OutOfBoundsException $e) {
             return false;
         }
 
-        return \Date::parse($this->determineFormat($chunks[3]), $date->tstamp);
+        return Date::parse($this->determineFormat($chunks[3]), $date->tstamp);
     }
 
 
@@ -133,7 +136,7 @@ class InsertTag
         if (\in_array($format, ['datim', 'date', 'time'], true)) {
             $key = $format.'Format';
 
-            return isset($GLOBALS['objPage']) ? $GLOBALS['objPage']->{$key} : \Config::get($key);
+            return isset($GLOBALS['objPage']) ? $GLOBALS['objPage']->{$key} : Config::get($key);
         }
 
         return $format;
@@ -175,7 +178,7 @@ class InsertTag
 
         // Custom format
         if (!in_array($strFormat, array('datim', 'date', 'time'))) {
-            return \Date::parse($strFormat, $intTimestamp);
+            return Date::parse($strFormat, $intTimestamp);
         }
 
         return Format::$strFormat($intTimestamp);
@@ -235,7 +238,7 @@ class InsertTag
     {
         $id    = $arrTag[1];
         $value = $arrTag[2];
-        $field = \FormFieldModel::findByPk($id);
+        $field = FormFieldModel::findByPk($id);
 
         if (null === $field) {
             return $value;

--- a/library/Haste/Util/Pagination.php
+++ b/library/Haste/Util/Pagination.php
@@ -12,6 +12,9 @@
 
 namespace Haste\Util;
 
+use Contao\Config;
+use Contao\Input;
+
 class Pagination
 {
 
@@ -90,7 +93,7 @@ class Pagination
         $this->setUrlParameter($urlParameter);
 
         // Default values
-        $this->setMaxPaginationLinks(\Config::get('maxPaginationLinks'));
+        $this->setMaxPaginationLinks(Config::get('maxPaginationLinks'));
     }
 
     /**
@@ -243,7 +246,7 @@ class Pagination
     /**
      * Gets the pagination object
      *
-     * @return \Pagination
+     * @return \Contao\Pagination
      * @throws \OutOfRangeException
      */
     public function getPagination()
@@ -284,7 +287,7 @@ class Pagination
             return;
         }
 
-        $page = \Input::get($this->getUrlParameter()) ?: 1;
+        $page = Input::get($this->getUrlParameter()) ?: 1;
 
         // Set limit and offset
         $limit = $this->getPerPage() ?: $this->getTotal();
@@ -295,7 +298,7 @@ class Pagination
             $limit = $this->getTotal() - $offset;
         }
 
-        $this->pagination = new \Pagination(
+        $this->pagination = new \Contao\Pagination(
             $this->getTotal(),
             $this->getPerPage(),
             $this->getMaxPaginationLinks(),

--- a/library/Haste/Util/StringUtil.php
+++ b/library/Haste/Util/StringUtil.php
@@ -12,6 +12,8 @@
 
 namespace Haste\Util;
 
+use Contao\Controller;
+
 /**
  * @author Andreas Schempp <https://github.com/aschempp>
  */
@@ -43,20 +45,20 @@ class StringUtil
         }
 
         // Must decode, tokens could be encoded
-        $strText = \StringUtil::decodeEntities($strText);
+        $strText = \Contao\StringUtil::decodeEntities($strText);
 
         // first parse the tokens as they might have if-else clauses
-        $strBuffer = \StringUtil::parseSimpleTokens($strText, $arrTokens);
+        $strBuffer = \Contao\StringUtil::parseSimpleTokens($strText, $arrTokens);
 
         // then replace the insert tags
-        $strBuffer = \Controller::replaceInsertTags($strBuffer, false);
+        $strBuffer = Controller::replaceInsertTags($strBuffer, false);
 
         // check if the insert tags have returned a simple token
         if (strpos($strBuffer, '##') !== false && $strBuffer != $strText) {
             $strBuffer = static::recursiveReplaceTokensAndTags($strBuffer, $arrTokens, $intTextFlags);
         }
 
-        $strBuffer = \StringUtil::restoreBasicEntities($strBuffer);
+        $strBuffer = \Contao\StringUtil::restoreBasicEntities($strBuffer);
 
         if ($intTextFlags > 0) {
             $strBuffer = static::convertToText($strBuffer, $intTextFlags);
@@ -84,7 +86,7 @@ class StringUtil
         }
 
         if ($options & static::NO_ENTITIES) {
-            $varValue = \StringUtil::restoreBasicEntities($varValue);
+            $varValue = \Contao\StringUtil::restoreBasicEntities($varValue);
             $varValue = html_entity_decode($varValue);
 
             // Convert non-breaking to regular white space

--- a/library/Haste/Util/Url.php
+++ b/library/Haste/Util/Url.php
@@ -12,6 +12,10 @@
 
 namespace Haste\Util;
 
+use Contao\Controller;
+use Contao\Environment;
+use Contao\PageModel;
+
 class Url
 {
 
@@ -122,16 +126,16 @@ class Url
     protected static function prepareUrl($varUrl)
     {
         if ($varUrl === null) {
-            $varUrl = \Environment::get('request');
+            $varUrl = Environment::get('request');
 
         } elseif (is_numeric($varUrl)) {
-            if (($objJump = \PageModel::findByPk($varUrl)) === null) {
+            if (($objJump = PageModel::findByPk($varUrl)) === null) {
                 throw new \InvalidArgumentException('Given page id does not exist.');
             }
 
-            $varUrl = \Controller::generateFrontendUrl($objJump->row());
+            $varUrl = Controller::generateFrontendUrl($objJump->row());
 
-            list(, $strQueryString) = explode('?', \Environment::get('request'), 2);
+            list(, $strQueryString) = explode('?', Environment::get('request'), 2);
 
             if ($strQueryString != '') {
                 $varUrl .= '?' . $strQueryString;


### PR DESCRIPTION
Trying to get rid of Contao's global namespaced classes.

When using `\Haste\Input\Input::getAutoItem(...)` for example PHPStan will report following:

```
Class Input not found.                                                  
💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
```

PS: There is a workaround - while bootstrapping PHPStan you can boot the Contao Framework, but that's a bit overkill IMO.