### PR TITLE
Use .gitattributes to exclude tests in production

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+.github export-ignore
+tests export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
This closes #164 with the help of `.gitattributes` file.

Related resources:

- https://git-scm.com/docs/gitattributes#_export_ignore
- https://php.watch/articles/composer-gitattributes#export-ignore