### PR TITLE
Prevent undefned array key warning in list() if the query string is empty

### DIFF
--- a/library/Haste/Util/Url.php
+++ b/library/Haste/Util/Url.php
@@ -33,7 +33,12 @@ class Url
         $strUrl = static::prepareUrl($varUrl);
         $strQuery = trim(ampersand($strQuery, false), '&');
 
-        list($strScript, $strQueryString) = explode('?', $strUrl, 2);
+        $arrUrl = explode('?', $strUrl, 2);
+
+        // Prevent undefined array key warning
+        $arrUrl[1] = $arrUrl[1] ?? '';
+
+        list($strScript, $strQueryString) = $arrUrl;
 
         parse_str($strQueryString, $queries);
 

--- a/library/Haste/Util/Url.php
+++ b/library/Haste/Util/Url.php
@@ -33,12 +33,7 @@ class Url
         $strUrl = static::prepareUrl($varUrl);
         $strQuery = trim(ampersand($strQuery, false), '&');
 
-        $arrUrl = explode('?', $strUrl, 2);
-
-        // Prevent undefined array key warning
-        $arrUrl[1] = $arrUrl[1] ?? '';
-
-        list($strScript, $strQueryString) = $arrUrl;
+        list($strScript, $strQueryString) = explode('?', $strUrl, 2) + array('', '');
 
         parse_str($strQueryString, $queries);
 


### PR DESCRIPTION
PHP 8.0:
Getting a undefined array key warning when calling`Haste\Util\Url::addQueryString('foo=bar')` and the current url has no query string.