### PR TITLE
Support boolean sql config when formatting DCA values

### DIFF
--- a/library/Haste/Util/Format.php
+++ b/library/Haste/Util/Format.php
@@ -184,7 +184,7 @@ class Format
         }
 
         if (($arrField['eval']['isBoolean'] ?? false) || ('checkbox' === ($arrField['inputType'] ?? null) && !($arrField['eval']['multiple'] ?? false))) {
-            return strlen($varValue) ? $GLOBALS['TL_LANG']['MSC']['yes'] : $GLOBALS['TL_LANG']['MSC']['no'];
+            return !empty($varValue) ? $GLOBALS['TL_LANG']['MSC']['yes'] : $GLOBALS['TL_LANG']['MSC']['no'];
         }
 
         if ('textarea' === ($arrField['inputType'] ?? null) && (($arrField['eval']['allowHtml'] ?? false) || ($arrField['eval']['preserveTags'] ?? false))) {


### PR DESCRIPTION
If you define boolean fields with correct sql in the dca (`'sql' => ['type' => 'boolean', 'default' => false]`) at the moment the output when formatting the value will be `yes` if the value is `false` (in the database `0` and not `''`)