### PR TITLE
Fix `Util\Url` when query string is empty

### DIFF
--- a/library/Haste/Util/Url.php
+++ b/library/Haste/Util/Url.php
@@ -135,7 +135,7 @@ class Url
 
             $varUrl = Controller::generateFrontendUrl($objJump->row());
 
-            list(, $strQueryString) = explode('?', Environment::get('request'), 2);
+            $strQueryString = Environment::get('queryString');
 
             if ($strQueryString != '') {
                 $varUrl .= '?' . $strQueryString;

--- a/library/Haste/Util/Url.php
+++ b/library/Haste/Util/Url.php
@@ -68,7 +68,7 @@ class Url
             return $strUrl;
         }
 
-        list($strScript, $strQueryString) = explode('?', $strUrl, 2);
+        list($strScript, $strQueryString) = explode('?', $strUrl, 2) + array('', '');
 
         parse_str($strQueryString, $queries);
 
@@ -96,7 +96,7 @@ class Url
     {
         $strUrl = static::prepareUrl($varUrl);
 
-        list($strScript, $strQueryString) = explode('?', $strUrl, 2);
+        list($strScript, $strQueryString) = explode('?', $strUrl, 2) + array('', '');
 
         parse_str($strQueryString, $queries);
 


### PR DESCRIPTION
Fixes #174

If I understand correctly, the purpose of this line is to get the current query string, if any? Can the Contao's helper method be used here then?