### PR TITLE
Fix DcaRelationsManager if table with column exists

### DIFF
--- a/src/DcaRelationsManager.php
+++ b/src/DcaRelationsManager.php
@@ -382,8 +382,13 @@ class DcaRelationsManager
                 unset($relation['related_sql']['type']);
 
                 $schemaTable = $schema->hasTable($relation['table']) ? $schema->getTable($relation['table']) : $schema->createTable($relation['table']);
-                $schemaTable->addColumn($relation['reference_field'], $referenceType, $relation['reference_sql']);
-                $schemaTable->addColumn($relation['related_field'], $relatedType, $relation['related_sql']);
+
+                if (!$schemaTable->hasColumn($relation['reference_field'])) {
+                    $schemaTable->addColumn($relation['reference_field'], $referenceType, $relation['reference_sql']);
+                }
+                if (!$schemaTable->hasColumn($relation['related_field'])) {
+                    $schemaTable->addColumn($relation['related_field'], $relatedType, $relation['related_sql']);
+                }
 
                 $indexName = $relation['reference_field'].'_'.$relation['related_field'];
 


### PR DESCRIPTION
After upgrading from `5.0.7` to `5.0.10` I got a `Doctrine\DBAL\Schema\Exception\ColumnAlreadyExists` while `contao:migrate`.
This PR checks if the relation columns already exist!