### PR TITLE
Set the correct empty value on execute post actions

### DIFF
--- a/src/EventListener/DcaAjaxOperationsListener.php
+++ b/src/EventListener/DcaAjaxOperationsListener.php
@@ -17,6 +17,7 @@ use Contao\Input;
 use Contao\StringUtil;
 use Contao\System;
 use Contao\Versions;
+use Contao\Widget;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -73,6 +74,11 @@ class DcaAjaxOperationsListener
 
         $value = $options[$nextIndex]['value'];
         $value = $this->executeSaveCallback($dc, $value, $settings);
+
+        // Set the correct empty value
+        if (!\is_array($value) && '' === (string) $value ) {
+            $value = Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$dc->table]['fields'][$settings['field']]['sql'] ?? []);
+        }
 
         // Update the database
         $this->connection->update($dc->table, [$settings['field'] => $value], ['id' => $id]);


### PR DESCRIPTION
This PR fixes #197

At the moment it could be that the value is no correct empty value for the database.