### PR TITLE
Cast return value of `preg_replace` to `string`

### DIFF
--- a/src/StringParser.php
+++ b/src/StringParser.php
@@ -76,7 +76,7 @@ class StringParser
             $value = str_replace("\xC2\xA0", ' ', $value);
 
             // Remove invisible control characters and unused code points
-            $value = preg_replace('/[\pC]/u', '', $value);
+            $value = (string) preg_replace('/[\pC]/u', '', $value);
         }
 
         // Replace friendly email before stripping tags


### PR DESCRIPTION
`preg_replace` can return null when an error occurs - which would then cause the following error down the line:

```
TypeError:
preg_match_all(): Argument #2 ($subject) must be of type string, null given

  at vendor/codefog/contao-haste/src/StringParser.php:85
```

@berecont can you test if this fixes your [issue](https://github.com/terminal42/contao-notification_center/issues/285)?