### PR TITLE
Fix ajax operation

### DIFF
--- a/docs/DcaAjaxOperations.md
+++ b/docs/DcaAjaxOperations.md
@@ -1,11 +1,11 @@
 # DcaAjaxOperations component
 
-This component is designed to help you handle the ajax "toggle" operations in DCA list view. 
+This component is designed to help you handle the ajax "toggle" operations in DCA list view.
 
 
 ## Usage
 
-If you have a boolean field with a specific icon naming (e.g. `featured.svg` and `featured_.svg`), then it is best 
+If you have a boolean field with a specific icon naming (e.g. `featured.svg` and `featured_.svg`), then it is best
 to use the Contao core features:
 
 ```php
@@ -29,7 +29,7 @@ to use the Contao core features:
 ],
 ```
 
-However, suppose you have a different file naming, multiple states per field, or need a custom permission check. 
+However, suppose you have a different file naming, multiple states per field, or need a custom permission check.
 In that case, this component is for you.
 
 Take a look at the example of how we would implement the regular "toggle published" operation:
@@ -40,7 +40,7 @@ $GLOBALS['TL_DCA']['tl_table']['list']['operations']['toggle_my_field'] = [
     'haste_ajax_operation' => [
         'field' => 'my_field',
         'options' => [
-            ['value' => '', 'icon' => 'invisible.svg'],
+            ['value' => '0', 'icon' => 'invisible.svg'],
             ['value' => '1', 'icon' => 'visible.svg'],
         ],
     ],

--- a/docs/DcaAjaxOperations.md
+++ b/docs/DcaAjaxOperations.md
@@ -1,11 +1,11 @@
 # DcaAjaxOperations component
 
-This component is designed to help you handle the ajax "toggle" operations in DCA list view.
+This component is designed to help you handle the ajax "toggle" operations in DCA list view. 
 
 
 ## Usage
 
-If you have a boolean field with a specific icon naming (e.g. `featured.svg` and `featured_.svg`), then it is best
+If you have a boolean field with a specific icon naming (e.g. `featured.svg` and `featured_.svg`), then it is best 
 to use the Contao core features:
 
 ```php
@@ -29,7 +29,7 @@ to use the Contao core features:
 ],
 ```
 
-However, suppose you have a different file naming, multiple states per field, or need a custom permission check.
+However, suppose you have a different file naming, multiple states per field, or need a custom permission check. 
 In that case, this component is for you.
 
 Take a look at the example of how we would implement the regular "toggle published" operation:

--- a/src/EventListener/DcaAjaxOperationsListener.php
+++ b/src/EventListener/DcaAjaxOperationsListener.php
@@ -18,6 +18,7 @@ use Contao\Input;
 use Contao\StringUtil;
 use Contao\System;
 use Contao\Versions;
+use Contao\Widget;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -81,6 +82,11 @@ class DcaAjaxOperationsListener
 
         $value = $options[$nextIndex]['value'];
         $value = $this->executeSaveCallback($dc, $value, $settings);
+
+        // Set the correct empty value
+        if (!\is_array($value) && '' === (string) $value ) {
+            $value = Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$dc->table]['fields'][$settings['field']]['sql'] ?? []);
+        }
 
         // Update the database
         $this->connection->update($dc->table, [$settings['field'] => $value], ['id' => $id]);

--- a/src/EventListener/DcaAjaxOperationsListener.php
+++ b/src/EventListener/DcaAjaxOperationsListener.php
@@ -84,7 +84,7 @@ class DcaAjaxOperationsListener
         $value = $this->executeSaveCallback($dc, $value, $settings);
 
         // Set the correct empty value
-        if (!\is_array($value) && '' === (string) $value ) {
+        if (!\is_array($value) && '' === (string) $value) {
             $value = Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$dc->table]['fields'][$settings['field']]['sql'] ?? []);
         }
 
@@ -211,7 +211,7 @@ class DcaAjaxOperationsListener
                 return '';
             }
 
-            $value = $row[$settings['field']];
+            $value = (string) $row[$settings['field']];
             $options = (array) $settings['options'];
             $icon = null;
 

--- a/src/EventListener/DcaAjaxOperationsListener.php
+++ b/src/EventListener/DcaAjaxOperationsListener.php
@@ -88,8 +88,11 @@ class DcaAjaxOperationsListener
             $value = Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$dc->table]['fields'][$settings['field']]['sql'] ?? []);
         }
 
+        // Set the correct parameter types
+        $types = array_filter([$GLOBALS['TL_DCA'][$dc->table]['fields'][$settings['field']]['sql']['type'] ?? null]);
+
         // Update the database
-        $this->connection->update($dc->table, [$settings['field'] => $value], ['id' => $id]);
+        $this->connection->update($dc->table, [$settings['field'] => $value], ['id' => $id], $types);
 
         // Create a new version
         $versions->create();


### PR DESCRIPTION
This is a follow up of #200 and fixes #197

- Set the correct empty value on execute post actions
- Set the correct parameter types
- Cast the database value to string for equal comparison.
- Update example for toggle published