### PR TITLE
Support Contao mono repo

### DIFF
--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -924,9 +924,10 @@ class Form
         }
 
         $widget = $this->widgets[$fieldName];
+        $contaoVersion = InstalledVersions::getVersion('contao/core-bundle') ?? InstalledVersions::getVersion('contao/contao');
 
         // Support file uploads in Contao 5
-        if (version_compare(InstalledVersions::getVersion('contao/core-bundle'), '5.0', '>=') && $widget instanceof UploadableWidgetInterface) {
+        if (version_compare($contaoVersion, '5.0', '>=') && $widget instanceof UploadableWidgetInterface) {
             return $widget->value;
         }
 

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -9,7 +9,6 @@ use Codefog\HasteBundle\DoctrineOrmHelper;
 use Codefog\HasteBundle\Form\Validator\ValidatorInterface;
 use Codefog\HasteBundle\Model\DcaRelationsModel;
 use Codefog\HasteBundle\Util\ArrayPosition;
-use Composer\InstalledVersions;
 use Contao\ArrayUtil;
 use Contao\Controller;
 use Contao\DataContainer;
@@ -924,10 +923,9 @@ class Form
         }
 
         $widget = $this->widgets[$fieldName];
-        $contaoVersion = InstalledVersions::getVersion('contao/core-bundle') ?? InstalledVersions::getVersion('contao/contao');
 
         // Support file uploads in Contao 5
-        if (version_compare($contaoVersion, '5.0', '>=') && $widget instanceof UploadableWidgetInterface) {
+        if ($widget instanceof UploadableWidgetInterface) {
             return $widget->value;
         }
 


### PR DESCRIPTION
When using the Contao mono repo the following error might occur:

```
TypeError:
version_compare(): Argument #1 ($version1) must be of type string, null given

  at vendor\codefog\contao-haste\src\Form\Form.php:929
  at version_compare(null, '5.0', '>=')
     (vendor\codefog\contao-haste\src\Form\Form.php:929)
```

This PR fixes that by allowing to fall back to the mono repo if `contao/core-bundle` is not found.