### PR TITLE
Allow `symfony/mime ^5.4` / Unlock contao 4.13 again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^8.1",
         "contao/core-bundle": "^4.13 || ^5.0",
-        "symfony/mime": "^6.0 || ^7.0"
+        "symfony/mime": "^5.4 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "contao/manager-plugin": "^2.0",


### PR DESCRIPTION
### Description

TL;DR:
Contao Haste in 5.2 is not installable on Contao 4.13

____

#221 introduced `symfony/mime` as a dependency, however, the minimum requirements were set to `^6.0 || ^7.0`.

Contao 4.13 needs `symfony/mime` in `^5.4`.

I've installed the change on a 4.13 with `symfony/mime` ^5.4 installed and did run the tests:
![image](https://github.com/codefog/contao-haste/assets/55794780/3981ec28-d567-4338-9ef9-802f32dd835d)

There is also no BC changes in the MimeTypeGuesser:
- https://github.com/symfony/mime/blob/6.4/MimeTypesInterface.php
- https://github.com/symfony/mime/blob/6.4/FileinfoMimeTypeGuesser.php
- https://github.com/symfony/mime/blob/6.4/FileBinaryMimeTypeGuesser.php

Changelog:
https://github.com/symfony/mime/blob/6.4/CHANGELOG.md