### PR TITLE
Add compatibility for Contao 5.4+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "require": {
         "php": "^8.1",
         "contao/core-bundle": "^4.13 || ^5.0",
-        "symfony/mime": "^5.4 || ^6.0 || ^7.0"
+        "symfony/mime": "^5.4 || ^6.0 || ^7.0",
+        "symfony/security-core": "^5.4 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "contao/manager-plugin": "^2.0",

--- a/config/services.yml
+++ b/config/services.yml
@@ -4,6 +4,7 @@ services:
         autoconfigure: true
         bind:
             string $projectDir: '%kernel.project_dir%'
+            $security: '@security.helper'
 
     # AjaxReload
     Codefog\HasteBundle\AjaxReloadManager:

--- a/config/services.yml
+++ b/config/services.yml
@@ -4,7 +4,6 @@ services:
         autoconfigure: true
         bind:
             string $projectDir: '%kernel.project_dir%'
-            $security: '@security.helper'
 
     # AjaxReload
     Codefog\HasteBundle\AjaxReloadManager:

--- a/src/DoctrineOrmHelper.php
+++ b/src/DoctrineOrmHelper.php
@@ -10,11 +10,8 @@ use Contao\FrontendUser;
 use Contao\Versions;
 use Doctrine\DBAL\Connection;
 use Doctrine\Persistence\ObjectManager;
-use Symfony\Bundle\SecurityBundle\Security as BundleSecurity;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Symfony\Component\Security\Core\Security as CoreSecurity;
-use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class DoctrineOrmHelper
 {
@@ -30,7 +27,7 @@ class DoctrineOrmHelper
         private readonly Connection $connection,
         private readonly DcaRelationsManager $dcaRelationsManager,
         private readonly RouterInterface $router,
-        private readonly AuthorizationCheckerInterface $security,
+        private readonly TokenStorageInterface $tokenStorage,
     ) {
     }
 
@@ -85,7 +82,7 @@ class DoctrineOrmHelper
         $versions = new Versions($objectManager->getClassMetadata($entity::class)->getTableName(), $entity->getId());
 
         // Set the frontend user, if any
-        if (($user = $this->getUser()) instanceof FrontendUser) {
+        if (($user = $this->tokenStorage->getToken()?->getUser()) instanceof FrontendUser) {
             $versions->setUsername($user->username);
             $versions->setUserId(0);
         }
@@ -145,18 +142,5 @@ class DoctrineOrmHelper
     private function getEntityUniqueId(object $entity): string
     {
         return $entity::class.'::'.spl_object_id($entity);
-    }
-
-    /**
-     * Helper function to get the user from the @security.helper service 
-     * to stay compatible with Contao 4.13, 5.3 and 5.4+.
-     */
-    private function getUser(): UserInterface|null
-    {
-        if ($this->security instanceof CoreSecurity || $this->security instanceof BundleSecurity) {
-            return $this->security->getUser();
-        }
-
-        return null;
     }
 }

--- a/src/EventListener/DcaAjaxOperationsListener.php
+++ b/src/EventListener/DcaAjaxOperationsListener.php
@@ -20,11 +20,11 @@ use Contao\System;
 use Contao\Versions;
 use Contao\Widget;
 use Doctrine\DBAL\Connection;
-use Symfony\Bundle\SecurityBundle\Security as BundleSecurity;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Security\Core\Security as CoreSecurity;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Security;
 
 class DcaAjaxOperationsListener
 {
@@ -35,7 +35,7 @@ class DcaAjaxOperationsListener
         private readonly ScopeMatcher $scopeMatcher,
         // To remain compatible with symfony/security-core 5.4 (Contao 4.13), 6.4 (Contao 5.3) and 7.0+ (Contao 5.4+),
         // we need to allow both types for the @security.helper service.
-        private readonly CoreSecurity|BundleSecurity $security,
+        private readonly Security|AuthorizationCheckerInterface $security,
         private readonly ContaoCsrfTokenManager $tokenManager,
     ) {
     }

--- a/src/EventListener/DcaAjaxOperationsListener.php
+++ b/src/EventListener/DcaAjaxOperationsListener.php
@@ -20,10 +20,11 @@ use Contao\System;
 use Contao\Versions;
 use Contao\Widget;
 use Doctrine\DBAL\Connection;
+use Symfony\Bundle\SecurityBundle\Security as BundleSecurity;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Security as CoreSecurity;
 
 class DcaAjaxOperationsListener
 {
@@ -32,7 +33,9 @@ class DcaAjaxOperationsListener
         private readonly Packages $packages,
         private readonly RequestStack $requestStack,
         private readonly ScopeMatcher $scopeMatcher,
-        private readonly Security $security,
+        // To remain compatible with symfony/security-core 5.4 (Contao 4.13), 6.4 (Contao 5.3) and 7.0+ (Contao 5.4+),
+        // we need to allow both types for the @security.helper service.
+        private readonly CoreSecurity|BundleSecurity $security,
         private readonly ContaoCsrfTokenManager $tokenManager,
     ) {
     }

--- a/src/EventListener/DcaAjaxOperationsListener.php
+++ b/src/EventListener/DcaAjaxOperationsListener.php
@@ -24,7 +24,6 @@ use Symfony\Component\Asset\Packages;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Symfony\Component\Security\Core\Security;
 
 class DcaAjaxOperationsListener
 {
@@ -33,9 +32,7 @@ class DcaAjaxOperationsListener
         private readonly Packages $packages,
         private readonly RequestStack $requestStack,
         private readonly ScopeMatcher $scopeMatcher,
-        // To remain compatible with symfony/security-core 5.4 (Contao 4.13), 6.4 (Contao 5.3) and 7.0+ (Contao 5.4+),
-        // we need to allow both types for the @security.helper service.
-        private readonly Security|AuthorizationCheckerInterface $security,
+        private readonly AuthorizationCheckerInterface $security,
         private readonly ContaoCsrfTokenManager $tokenManager,
     ) {
     }


### PR DESCRIPTION
Fixes #223 

This adds compatibility for Contao 5.4+ by allowing both the deprecated and the new type for the `@security.helper` service.