### PR TITLE
Get URI from `RequestStack` in `UrlParser`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "php": "^8.1",
         "contao/core-bundle": "^4.13 || ^5.0",
         "symfony/mime": "^5.4 || ^6.0 || ^7.0",
+        "symfony/deprecation-contracts": "^2.1 || ^3.0",
         "symfony/security-core": "^5.4 || ^6.0 || ^7.0"
     },
     "require-dev": {


### PR DESCRIPTION
The `UrlParser` is registered as a service, however it retrieves the URI from the legacy `Environment` class instead of the `RequestStack`. This PR changes that.

Similar to https://github.com/codefog/contao-haste/pull/222