### PR TITLE
Support indexed keys of file uploads in file upload normalizer

### DIFF
--- a/src/FileUploadNormalizer.php
+++ b/src/FileUploadNormalizer.php
@@ -33,6 +33,7 @@ class FileUploadNormalizer
     public function normalize(array $files): array
     {
         $standardizedPerKey = [];
+        $groups = [];
 
         foreach ($files as $k => $file) {
             switch (true) {
@@ -55,6 +56,25 @@ class FileUploadNormalizer
                 case null !== ($filePath = $this->extractFilePath($file)):
                     $standardizedPerKey[$k][] = $this->fromFile($filePath);
                     break;
+            }
+
+            if (str_ends_with($k, '_0')) {
+                $groups[] = substr($k, 0, -2);
+            }
+        }
+
+        foreach ($groups as $group) {
+            if (array_key_exists($group, $standardizedPerKey)) {
+                continue;
+            }
+
+            $standardizedPerKey[$group] = [];
+
+            foreach ($standardizedPerKey as $k => $file) {
+                if (1 === \count($file) && preg_match('/^'.preg_quote($group, '/').'_\d+$/', $k)) {
+                    $standardizedPerKey[$group][] = reset($file);
+                    unset($standardizedPerKey[$k]);
+                }
             }
         }
 

--- a/src/FileUploadNormalizer.php
+++ b/src/FileUploadNormalizer.php
@@ -58,7 +58,7 @@ class FileUploadNormalizer
                     break;
             }
 
-            if (str_ends_with($k, '_0')) {
+            if (is_string($k) && str_ends_with($k, '_0')) {
                 $groups[] = substr($k, 0, -2);
             }
         }

--- a/tests/FileUploadNormalizerTest.php
+++ b/tests/FileUploadNormalizerTest.php
@@ -118,6 +118,54 @@ class FileUploadNormalizerTest extends TestCase
             null,
         ];
 
+        yield 'File upload with indexed keys' => [
+            [
+                'file_0' => [
+                    'name' => 'name.jpg',
+                    'type' => 'image/jpeg',
+                    'tmp_name' => 'path/to/name.jpg',
+                    'error' => 0,
+                    'size' => 333,
+                    'uploaded' => true,
+                    'uuid' => '660d272c-f4c3-11ed-a05b-0242ac120003',
+                ],
+                'file_1' => [
+                    'name' => 'name.jpg',
+                    'type' => 'image/jpeg',
+                    'tmp_name' => 'path/to/name.jpg',
+                    'error' => 0,
+                    'size' => 333,
+                    'uploaded' => true,
+                    'uuid' => '660d272c-f4c3-11ed-a05b-0242ac120003',
+                ],
+            ],
+            [
+                'file' => [
+                    [
+                        'name' => 'name.jpg',
+                        'type' => 'image/jpeg',
+                        'tmp_name' => 'path/to/name.jpg',
+                        'error' => 0,
+                        'size' => 333,
+                        'uploaded' => true,
+                        'uuid' => '660d272c-f4c3-11ed-a05b-0242ac120003',
+                    ],
+                    [
+                        'name' => 'name.jpg',
+                        'type' => 'image/jpeg',
+                        'tmp_name' => 'path/to/name.jpg',
+                        'error' => 0,
+                        'size' => 333,
+                        'uploaded' => true,
+                        'uuid' => '660d272c-f4c3-11ed-a05b-0242ac120003',
+                    ],
+                ],
+            ],
+            '/project-dir',
+            null,
+            null,
+        ];
+
         yield 'Array of it all' => [
             [
                 'upload_field_already_correct' => [


### PR DESCRIPTION
Since Contao does not have a built-in support for "multiple file uploads", our `terminal42/contao-fineuploader` has added a handler in Contao 5 to convert an array of uploads to separate upload fields. So if you have an input field `attachements` with fineuploader, you would get an `attachements_0`, `attachements_1` etc. property in `$files` of Contao's `processFormData` hook.

This PR normalizes this back to the expected format of normalized files (`attachements => [0 => ..., 1 => ...]`).