### PR TITLE
Fix `--prefer-lowest` tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "php": "^8.1",
-        "contao/core-bundle": "^4.13.2 || ^5.0",
+        "contao/core-bundle": "^4.13.41 || ^5.3.5",
         "symfony/mime": "^5.4 || ^6.0 || ^7.0",
         "symfony/deprecation-contracts": "^2.1 || ^3.0",
         "symfony/security-core": "^5.4 || ^6.0 || ^7.0"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "php": "^8.1",
-        "contao/core-bundle": "^4.13 || ^5.0",
+        "contao/core-bundle": "^4.13.2 || ^5.0",
         "symfony/mime": "^5.4 || ^6.0 || ^7.0",
         "symfony/deprecation-contracts": "^2.1 || ^3.0",
         "symfony/security-core": "^5.4 || ^6.0 || ^7.0"


### PR DESCRIPTION
`VirtualFileSystemInterface::get()` was introduced in Contao `4.13.2`, so we need to raise the minimum dependency accordingly.
`FilesSystem::getName()` was introduced in Contao `4.13.41` and `5.3.5`, so we need to raise the minimum dependency further accordingly.