### PR TITLE
Fix incorrect date/time for null values in Format.php

### DIFF
--- a/library/Haste/Util/Format.php
+++ b/library/Haste/Util/Format.php
@@ -176,15 +176,15 @@ class Format
         }
 
         if ('date' === ($arrField['eval']['rgxp'] ?? null)) {
-            return static::date($varValue);
+            return '' !== (string) $varValue ? static::date($varValue) : '';
         }
 
         if ('time' === ($arrField['eval']['rgxp'] ?? null)) {
-            return static::time($varValue);
+            return '' !== (string) $varValue ? static::time($varValue) : '';
         }
 
         if ('datim' === ($arrField['eval']['rgxp'] ?? null) || in_array(($arrField['flag'] ?? null), array(5, 6, 7, 8, 9, 10)) || 'tstamp' === ($arrField['name'] ?? null)) {
-            return static::datim($varValue);
+            return '' !== (string) $varValue ? static::datim($varValue) : '';
         }
 
         if (($arrField['eval']['isBoolean'] ?? false) || ('checkbox' === ($arrField['inputType'] ?? null) && !($arrField['eval']['multiple'] ?? false))) {


### PR DESCRIPTION
If the value is null the current date/time/datim is returned, because the Date::parse() function that is called by System::parseDate() falls back to the current time if the timestamp is null.
This only affects Haste 4.x, Haste 5.x fixed this behaviour with basically the same check.

Reference: https://github.com/isotope/core/pull/2563