### PR TITLE
Add Twig extension for Haste formatter

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -40,6 +40,8 @@ services:
             $entityManager: '@?doctrine.orm.entity_manager'
         public: true
 
+    Codefog\HasteBundle\Twig\HasteExtension: ~
+
     # StringParser
     Codefog\HasteBundle\StringParser:
         public: true

--- a/docs/Formatter.md
+++ b/docs/Formatter.md
@@ -21,3 +21,27 @@ $this->formatter->dcaLabel('tl_news', 'headline');
 // Display the tl_news.source formatted value
 $this->formatter->dcaValue('tl_news', 'source', $newsModel->source);
 ```
+
+
+## Twig Usage
+
+You can also use the formatting helper inside Twig templates.
+
+```twig
+<table>
+<thead>
+    <tr>
+        <th>{{ dca_label('tl_news', 'headline') }}</th>
+        <th>{{ dca_label('tl_news', 'published') }}</th>
+    </tr>
+</thead>
+<tbody>
+    {% for item in news %}
+        <tr>
+            <td>{{ dca_value('tl_news', 'headline', item.headline) }}</td>
+            <td>{{ dca_value('tl_news', 'published', item.published) }}</td>
+        </tr>
+    {% endfor %}
+</tbody>
+</table>
+```

--- a/src/Twig/HasteExtension.php
+++ b/src/Twig/HasteExtension.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codefog\HasteBundle\Twig;
+
+use Codefog\HasteBundle\Formatter;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+class HasteExtension extends AbstractExtension
+{
+    public function __construct(private readonly Formatter $formatter)
+    {
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('dca_label', $this->formatter->dcaLabel(...)),
+            new TwigFunction('dca_value', $this->formatter->dcaValue(...)),
+        ];
+    }
+}


### PR DESCRIPTION
This adds two Twig methods to use the Haste Formatter in templates.