### PR TITLE
Add BC for the backend_icon Twig helper

### DIFF
--- a/src/Twig/HasteExtension.php
+++ b/src/Twig/HasteExtension.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Codefog\HasteBundle\Twig;
 
 use Codefog\HasteBundle\Formatter;
+use Contao\CoreBundle\String\HtmlAttributes;
+use Contao\CoreBundle\Twig\Runtime\BackendHelperRuntime;
+use Contao\Image;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -16,9 +19,24 @@ class HasteExtension extends AbstractExtension
 
     public function getFunctions(): array
     {
-        return [
+        $functions = [
             new TwigFunction('dca_label', $this->formatter->dcaLabel(...)),
             new TwigFunction('dca_value', $this->formatter->dcaValue(...)),
         ];
+
+        if (!class_exists(BackendHelperRuntime::class)) {
+            $functions[] = new TwigFunction(
+                'backend_icon',
+                $this->generateIcon(...),
+                ['is_safe' => ['html']],
+            );
+        }
+
+        return $functions;
+    }
+
+    private function generateIcon(string $src, string $alt = '', HtmlAttributes|null $attributes = null): string
+    {
+        return Image::getHtml($src, $alt, $attributes ? $attributes->toString(false) : '');
     }
 }


### PR DESCRIPTION
This is the thing I miss most when working with Twig in the backend of Contao 5.3. This PR adds a forward-compatible layer for Contao 5.5