### PR TITLE
Properly close the `tl_select_wrapper` when options are empty

### DIFF
--- a/src/DcaRelationsManager.php
+++ b/src/DcaRelationsManager.php
@@ -604,6 +604,10 @@ class DcaRelationsManager
             if (0 === \count($ids)) {
                 $return .= '</select> ';
 
+                if ($updatePanelState) {
+                    $return .= '</div>';
+                }
+
                 // Add the line-break after 5 elements
                 if (0 === ++$count % 5) {
                     $return .= '<br>';


### PR DESCRIPTION
### Description

- fixes #246 
- fixes https://github.com/terminal42/contao-node/issues/65#issuecomment-4004017114

If there are no options, the `tl_select_wrapper` is never closed.